### PR TITLE
Implement offline pipeline flow with phase and rep detection

### DIFF
--- a/aiwa_milestone_a/lib/pipeline/counting.dart
+++ b/aiwa_milestone_a/lib/pipeline/counting.dart
@@ -1,4 +1,9 @@
-class Rep { final int startMs, valleyMs, endMs; Rep(this.startMs,this.valleyMs,this.endMs); }
+import 'dart:math' as math;
+
+class Rep {
+  final int startMs, valleyMs, endMs;
+  Rep(this.startMs, this.valleyMs, this.endMs);
+}
 
 List<Rep> countReps({
   required List<int> tMs,
@@ -6,10 +11,68 @@ List<Rep> countReps({
   required List<double?> kneeR,
   required int minIntervalMs,
   required int windowMs,
-  required num minValleyKneeAngle, // 按 strict/relaxed 选择
+  required num minValleyKneeAngle,
 }) {
-  // knee_main = min(kneeL, kneeR)（若一侧缺测则取另一侧；两侧皆缺测则该点无效）
-  // 在 Down→Up 窗口内寻找谷值，判定谷值 < minValleyKneeAngle 即计数
-  // ……（实现略，遵循 v1.1）
-  return <Rep>[];
+  final n = tMs.length;
+  final mainAngles = List<double?>.generate(n, (i) {
+    final l = kneeL[i];
+    final r = kneeR[i];
+    if (l == null && r == null) return null;
+    if (l == null) return r;
+    if (r == null) return l;
+    return math.min(l, r);
+  });
+
+  final reps = <Rep>[];
+  int? lastEnd;
+
+  for (var i = 0; i < n; i++) {
+    final centerAngle = mainAngles[i];
+    if (centerAngle == null) continue;
+
+    final centerTime = tMs[i];
+    var left = i;
+    while (left > 0 && centerTime - tMs[left - 1] <= windowMs) {
+      left--;
+    }
+    var right = i;
+    while (right + 1 < n && tMs[right + 1] - centerTime <= windowMs) {
+      right++;
+    }
+    if (left == i || right == i) continue;
+
+    var hasHigherLeft = false;
+    var hasHigherRight = false;
+    var strictlyLowerExists = false;
+
+    for (var j = left; j <= right; j++) {
+      final v = mainAngles[j];
+      if (v == null) continue;
+      if (j < i) {
+        if (v > centerAngle + 1e-3) hasHigherLeft = true;
+        if (v < centerAngle - 1e-3) {
+          strictlyLowerExists = true;
+          break;
+        }
+      } else if (j > i) {
+        if (v > centerAngle + 1e-3) hasHigherRight = true;
+        if (v < centerAngle - 1e-3) {
+          strictlyLowerExists = true;
+          break;
+        }
+      }
+    }
+    if (strictlyLowerExists) continue;
+    if (!hasHigherLeft || !hasHigherRight) continue;
+    if (centerAngle >= minValleyKneeAngle) continue;
+
+    final startMs = tMs[left];
+    final endMs = tMs[right];
+    if (lastEnd != null && centerTime - lastEnd < minIntervalMs) continue;
+
+    reps.add(Rep(startMs, centerTime, endMs));
+    lastEnd = endMs;
+  }
+
+  return reps;
 }

--- a/aiwa_milestone_a/lib/pipeline/offline_pipeline.dart
+++ b/aiwa_milestone_a/lib/pipeline/offline_pipeline.dart
@@ -1,65 +1,209 @@
-import '../spec/rule_models.dart';
+import 'dart:math' as math;
+
+import '../core/rounding.dart';
+import '../math/angles.dart';
+import '../math/one_euro.dart';
 import '../pose/kp_models.dart';
+import '../pose/movenet17_adapter.dart';
 import '../result/csv_export.dart';
+import '../spec/rule_models.dart';
+
+import 'counting.dart';
+import 'phases.dart';
+import 'quality.dart';
 
 class OfflinePipeline {
   final RuleSet rules;
   final Strictness strictness;
   OfflinePipeline(this.rules, this.strictness);
 
-  Future<({String anglesCsv, Map<String, dynamic> resultJson})> run(KeypointSeries kp) async {
-    print("=== Debug: first 3 frames keypoint scores (L/R hip,knee,ankle) ===");
+  Future<({String anglesCsv, Map<String, dynamic> resultJson})> run(
+      KeypointSeries kp) async {
+    final frames = kp.frames;
+    final tMs = frames.map((f) => f.tMs).toList(growable: false);
 
-    // MoveNet17 索引（A阶段）
-    const L_SHOULDER = 5, R_SHOULDER = 6;
-    const L_HIP = 11, R_HIP = 12;
-    const L_KNEE = 13, R_KNEE = 14;
-    const L_ANKLE = 15, R_ANKLE = 16;
+    final filteredPts = _filterKeypoints(frames);
+    final angles = _computeAngles(filteredPts);
 
-    for (int i = 0; i < 3 && i < kp.frames.length; i++) {
-      final pts = kp.frames[i].pts; // [[x,y,score], ...] 长度应为17
-      final vals = [
-        pts[L_HIP][2], pts[R_HIP][2],
-        pts[L_KNEE][2], pts[R_KNEE][2],
-        pts[L_ANKLE][2], pts[R_ANKLE][2],
-      ];
-      print("Frame $i scores = $vals");
-    }
-
-    // === v1.1：用关键点可用性计算 coverage（与角度链路解耦） ===
-    int ok = 0, total = kp.frames.length;
-    bool valid(List<List<num>> pts, int idx) => pts[idx][2] > 0.0; // v1.1 冻结
-    for (final fr in kp.frames) {
-      final pts = fr.pts;
-      final good =
-          valid(pts, L_HIP) && valid(pts, R_HIP) &&
-          valid(pts, L_KNEE) && valid(pts, R_KNEE) &&
-          valid(pts, L_ANKLE) && valid(pts, R_ANKLE);
-      if (good) ok++;
-    }
-    final cov = total == 0 ? 0.0 : ok / total;
-    final coverage = ((cov * 1000).roundToDouble() / 1000.0); // 三位小数
-    final lowConfidence = cov < 0.7; // v1.1 冻结质量阈值
-
-    // 角度：先维持占位（留空）；下一步再补 knee/trunk 计算
     final rows = <List<num?>>[];
-    for (final f in kp.frames) {
-      rows.add([f.tMs, null, null, null]); // t_ms,knee_L,knee_R,trunk_deg
+    for (var i = 0; i < frames.length; i++) {
+      rows.add([
+        frames[i].tMs,
+        angles.kneeL[i],
+        angles.kneeR[i],
+        angles.trunk[i],
+      ]);
     }
     final anglesCsv = buildAnglesCsv(rows);
 
+    final mainKnee = List<double?>.generate(frames.length, (i) {
+      final l = angles.kneeL[i];
+      final r = angles.kneeR[i];
+      if (l == null && r == null) return null;
+      if (l == null) return r;
+      if (r == null) return l;
+      return math.min(l, r);
+    }, growable: false);
+
+    final minPhaseMs = (rules.phases['minMs'] as num?)?.toInt() ?? 250;
+    final phaseSegs = segmentDownUp(tMs, mainKnee, minMs: minPhaseMs);
+
+    final counts = rules.counts;
+    final minIntervalMs = (counts['minIntervalMs'] as num?)?.toInt() ?? 600;
+    final windowMs = (counts['windowMs'] as num?)?.toInt() ?? 150;
+    final strictProfile =
+        (rules.strictness[strictness.value] as Map?) ?? const <String, dynamic>{};
+    final minValley =
+        (strictProfile['minValleyKneeAngle'] as num?) ?? (strictness == Strictness.strict ? 80 : 90);
+
+    final reps = countReps(
+      tMs: tMs,
+      kneeL: angles.kneeL,
+      kneeR: angles.kneeR,
+      minIntervalMs: minIntervalMs,
+      windowMs: windowMs,
+      minValleyKneeAngle: minValley,
+    );
+
+    final quality = computeQualityFromKeypoints(
+        frames.map((f) => f.pts.map((e) => e.cast<num>()).toList()).toList());
+
+    final repSummaries = reps.asMap().entries.map((entry) {
+      final idx = entry.key;
+      final rep = entry.value;
+      final valleyAngle = _angleAt(mainKnee, tMs, rep.valleyMs);
+      return {
+        'index': idx + 1,
+        'startMs': rep.startMs,
+        'valleyMs': rep.valleyMs,
+        'endMs': rep.endMs,
+        if (valleyAngle != null) 'kneeValleyAngle': round1(valleyAngle),
+      };
+    }).toList();
+
+    final evidence = <Map<String, dynamic>>[
+      ...phaseSegs.map((seg) => {
+            'type': seg.isDown ? 'phaseDown' : 'phaseUp',
+            'startMs': seg.startMs,
+            'endMs': seg.endMs,
+          }),
+      ...repSummaries.map((rep) => {
+            'type': 'rep',
+            ...rep,
+          }),
+    ];
+
     final resultJson = <String, dynamic>{
       'meta': {
+        'template': rules.template,
         'fps': kp.fps,
         'ruleVersion': rules.version,
         'strictness': strictness.value,
       },
-      'quality': { 'coverage': coverage, 'lowConfidence': lowConfidence },
-      'reps': 0, // fake 3 帧不满足 600ms/250ms，这是预期
-      'scores': { 'overall': 0.0, 'form': 0.0, 'stability': 0.0, 'tempo': 0.0 },
-      'issues': [],
-      'evidence': [],
+      'quality': {
+        'coverage': quality.coverage,
+        'lowConfidence': quality.lowConfidence,
+      },
+      'repCount': reps.length,
+      'reps': repSummaries,
+      'scores': {
+        'overall': 0.0,
+        'form': 0.0,
+        'stability': 0.0,
+        'tempo': 0.0,
+      },
+      'issues': <Map<String, dynamic>>[],
+      'evidence': evidence,
     };
+
     return (anglesCsv: anglesCsv, resultJson: resultJson);
   }
+}
+
+({List<double?> kneeL, List<double?> kneeR, List<double?> trunk}) _computeAngles(
+    List<List<List<double>>> filteredPts) {
+  final kneeL = <double?>[];
+  final kneeR = <double?>[];
+  final trunk = <double?>[];
+
+  for (final pts in filteredPts) {
+    kneeL.add(_kneeAngle(pts, L_HIP, L_KNEE, L_ANKLE));
+    kneeR.add(_kneeAngle(pts, R_HIP, R_KNEE, R_ANKLE));
+    trunk.add(_trunkAngle(pts));
+  }
+
+  return (kneeL: kneeL, kneeR: kneeR, trunk: trunk);
+}
+
+bool _valid(List<List<double>> pts, int idx) => pts[idx][2] > 0.0;
+
+double? _kneeAngle(List<List<double>> pts, int hipIdx, int kneeIdx, int ankleIdx) {
+  if (!_valid(pts, hipIdx) || !_valid(pts, kneeIdx) || !_valid(pts, ankleIdx)) {
+    return null;
+  }
+  final hip = V2(pts[hipIdx][0], pts[hipIdx][1]);
+  final knee = V2(pts[kneeIdx][0], pts[kneeIdx][1]);
+  final ankle = V2(pts[ankleIdx][0], pts[ankleIdx][1]);
+  try {
+    return round1(angleABC(hip, knee, ankle));
+  } catch (_) {
+    return null;
+  }
+}
+
+double? _trunkAngle(List<List<double>> pts) {
+  double? single(int shoulderIdx, int hipIdx) {
+    if (!_valid(pts, shoulderIdx) || !_valid(pts, hipIdx)) {
+      return null;
+    }
+    final shoulder = V2(pts[shoulderIdx][0], pts[shoulderIdx][1]);
+    final hip = V2(pts[hipIdx][0], pts[hipIdx][1]);
+    try {
+      return trunkAngle(shoulder, hip);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  final left = single(L_SHOULDER, L_HIP_IDX);
+  final right = single(R_SHOULDER, R_HIP_IDX);
+  if (left != null && right != null) {
+    return round1((left + right) / 2.0);
+  }
+  final value = left ?? right;
+  return value == null ? null : round1(value);
+}
+
+List<List<List<double>>> _filterKeypoints(List<KPFrame> frames) {
+  const kpCount = 17;
+  final filters = List.generate(
+      kpCount, (_) => (x: OneEuroFilter(), y: OneEuroFilter()));
+
+  final smoothed = <List<List<double>>>[];
+  for (final frame in frames) {
+    final tSec = frame.tMs / 1000.0;
+    final pts = <List<double>>[];
+    for (var i = 0; i < kpCount; i++) {
+      final raw = frame.pts[i];
+      final score = raw[2];
+      if (score <= 0) {
+        pts.add([raw[0].toDouble(), raw[1].toDouble(), score.toDouble()]);
+        continue;
+      }
+      final fx = filters[i].x.filter(tSec, raw[0].toDouble());
+      final fy = filters[i].y.filter(tSec, raw[1].toDouble());
+      pts.add([fx, fy, score.toDouble()]);
+    }
+    smoothed.add(pts);
+  }
+  return smoothed;
+}
+
+double? _angleAt(List<double?> angles, List<int> tMs, int targetMs) {
+  for (var i = 0; i < angles.length; i++) {
+    if (tMs[i] == targetMs) {
+      return angles[i];
+    }
+  }
+  return null;
 }

--- a/aiwa_milestone_a/lib/pipeline/phases.dart
+++ b/aiwa_milestone_a/lib/pipeline/phases.dart
@@ -1,11 +1,58 @@
 class PhaseSeg {
   final int startMs, endMs;
-  PhaseSeg(this.startMs, this.endMs);
+  final bool isDown; // true 表示下蹲 (angle decreasing)，false 表示起身 (angle increasing)
+  PhaseSeg(this.startMs, this.endMs, this.isDown);
 }
 
-// 简化：基于 knee_main 一阶差分方向 + minMs=250（或规则覆盖）
-List<PhaseSeg> segmentDownUp(List<int> tMs, List<double?> kneeMain, {required int minMs}) {
-  // 生成 Down 与 Up 的时间段，确保每段持续 ≥ minMs（缺测帧不改变趋势，直接跳过）
-  // ……（实现略，按 v1.1 口径）
-  return <PhaseSeg>[];
+List<PhaseSeg> segmentDownUp(List<int> tMs, List<double?> kneeMain,
+    {required int minMs}) {
+  final samples = <({int t, double angle})>[];
+  for (var i = 0; i < kneeMain.length; i++) {
+    final angle = kneeMain[i];
+    if (angle != null) {
+      samples.add((t: tMs[i], angle: angle));
+    }
+  }
+  if (samples.length < 2) {
+    return <PhaseSeg>[];
+  }
+
+  final segs = <PhaseSeg>[];
+  bool? currentDown;
+  int? segStart;
+  var prev = samples.first;
+
+  for (var i = 1; i < samples.length; i++) {
+    final curr = samples[i];
+    final diff = curr.angle - prev.angle;
+    if (diff.abs() < 1e-3) {
+      prev = curr;
+      continue;
+    }
+
+    final isDown = diff < 0;
+    if (currentDown == null) {
+      currentDown = isDown;
+      segStart = prev.t;
+    } else if (isDown != currentDown) {
+      final segEnd = prev.t;
+      if (segStart != null && segEnd - segStart >= minMs) {
+        segs.add(PhaseSeg(segStart, segEnd, currentDown));
+      }
+      currentDown = isDown;
+      segStart = prev.t;
+    }
+
+    prev = curr;
+  }
+
+  if (currentDown != null) {
+    final segEnd = prev.t;
+    final start = segStart ?? samples.first.t;
+    if (segEnd - start >= minMs) {
+      segs.add(PhaseSeg(start, segEnd, currentDown));
+    }
+  }
+
+  return segs;
 }


### PR DESCRIPTION
## Summary
- add phase segmentation and repetition counting utilities for knee angle series
- implement OfflinePipeline to smooth keypoints, compute angles, reps, quality, and evidence outputs

## Testing
- not run (Dart SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68d8bb36267083269f7f7a60a512ff1f