### PR TITLE
Align angles export precision and enhance rule validation

### DIFF
--- a/aiwa_milestone_a/lib/result/csv_export.dart
+++ b/aiwa_milestone_a/lib/result/csv_export.dart
@@ -1,8 +1,25 @@
 import 'package:csv/csv.dart';
 
+import '../core/rounding.dart';
+
 // rows: [ [t_ms, knee_L?, knee_R?, trunk_deg?], ... ]
 String buildAnglesCsv(List<List<num?>> rows) {
-  final header = ['t_ms','knee_L','knee_R','trunk_deg'];
-  final data = [header, ...rows.map((r) => r.map((v) => v == null ? '' : v).toList())];
+  final header = ['t_ms', 'knee_L', 'knee_R', 'trunk_deg'];
+  final data = [
+    header,
+    ...rows.map((row) {
+      final converted = <Object?>[row[0]];
+      for (var i = 1; i < row.length; i++) {
+        final value = row[i];
+        if (value == null) {
+          converted.add('');
+        } else {
+          final rounded = round3(value as num);
+          converted.add(rounded.toStringAsFixed(3));
+        }
+      }
+      return converted;
+    })
+  ];
   return const ListToCsvConverter(eol: '\n').convert(data);
 }

--- a/aiwa_milestone_a/lib/spec/rule_schema.dart
+++ b/aiwa_milestone_a/lib/spec/rule_schema.dart
@@ -6,7 +6,9 @@ void expect(bool cond, String msg) {
 
 double _ensureNum(Object? v, String path) {
   expect(v is num, '$path must be a number, got ${v.runtimeType}');
-  return (v as num).toDouble();
+  final value = (v as num).toDouble();
+  expect(value.isFinite, '$path must be finite, got $value');
+  return value;
 }
 
 Map<String, dynamic> _ensureMap(Object? v, String path) {
@@ -19,18 +21,37 @@ List _ensureList(Object? v, String path) {
   return v as List;
 }
 
-void _validateStrictnessMap(
+({double relaxed, double strict}) _validateStrictnessMap(
   Map<String, dynamic> map,
   String path, {
   required double min,
   required double max,
+  int? strictVsRelaxed,
 }) {
-  for (final key in ['relaxed', 'strict']) {
-    expect(map.containsKey(key), '$path.$key missing');
-    final value = _ensureNum(map[key], '$path.$key');
-    expect(value >= min && value <= max,
-        '$path.$key must be within [$min,$max], got $value');
+  expect(map.containsKey('relaxed'), '$path.relaxed missing');
+  expect(map.containsKey('strict'), '$path.strict missing');
+  final relaxed = _ensureNum(map['relaxed'], '$path.relaxed');
+  final strict = _ensureNum(map['strict'], '$path.strict');
+  expect(relaxed >= min && relaxed <= max,
+      '$path.relaxed must be within [$min,$max], got $relaxed');
+  expect(strict >= min && strict <= max,
+      '$path.strict must be within [$min,$max], got $strict');
+
+  if (strictVsRelaxed != null) {
+    const eps = 1e-6;
+    if (strictVsRelaxed < 0) {
+      expect(strict <= relaxed + eps,
+          '$path.strict must be <= $path.relaxed (got $strict vs $relaxed)');
+    } else if (strictVsRelaxed > 0) {
+      expect(strict >= relaxed - eps,
+          '$path.strict must be >= $path.relaxed (got $strict vs $relaxed)');
+    } else {
+      expect((strict - relaxed).abs() <= eps,
+          '$path.strict must equal $path.relaxed (got $strict vs $relaxed)');
+    }
   }
+
+  return (relaxed: relaxed, strict: strict);
 }
 
 void validateRuleMap(Map<String, dynamic> m) {
@@ -55,27 +76,40 @@ void validateRuleMap(Map<String, dynamic> m) {
   final metrics = _ensureMap(m['metrics'], 'metrics');
 
   final depth = _ensureMap(metrics['depth'], 'metrics.depth');
-  _validateStrictnessMap(_ensureMap(depth['kneeAngleMin'], 'metrics.depth.kneeAngleMin'),
+  expect(depth.containsKey('kneeAngleMin'), 'metrics.depth.kneeAngleMin missing');
+  _validateStrictnessMap(
+      _ensureMap(depth['kneeAngleMin'], 'metrics.depth.kneeAngleMin'),
       'metrics.depth.kneeAngleMin',
-      min: 0, max: 180);
+      min: 0,
+      max: 180,
+      strictVsRelaxed: -1);
 
   final valgus = _ensureMap(metrics['valgus'], 'metrics.valgus');
+  expect(valgus.containsKey('kneeOutAngleMin'),
+      'metrics.valgus.kneeOutAngleMin missing');
   _validateStrictnessMap(
       _ensureMap(valgus['kneeOutAngleMin'], 'metrics.valgus.kneeOutAngleMin'),
       'metrics.valgus.kneeOutAngleMin',
-      min: 0, max: 90);
+      min: 0,
+      max: 90,
+      strictVsRelaxed: 1);
   if (valgus.containsKey('windowMs')) {
     final window = _ensureNum(valgus['windowMs'], 'metrics.valgus.windowMs');
     expect(window > 0, 'metrics.valgus.windowMs must be > 0');
   }
 
   final trunk = _ensureMap(metrics['trunk'], 'metrics.trunk');
+  expect(trunk.containsKey('maxForwardLean'),
+      'metrics.trunk.maxForwardLean missing');
   _validateStrictnessMap(
       _ensureMap(trunk['maxForwardLean'], 'metrics.trunk.maxForwardLean'),
       'metrics.trunk.maxForwardLean',
-      min: 0, max: 90);
+      min: 0,
+      max: 90,
+      strictVsRelaxed: -1);
 
   final tempo = _ensureMap(metrics['tempo'], 'metrics.tempo');
+  expect(tempo.containsKey('eccentricMs'), 'metrics.tempo.eccentricMs missing');
   final eccentric = _ensureList(tempo['eccentricMs'], 'metrics.tempo.eccentricMs');
   expect(eccentric.length == 2, 'metrics.tempo.eccentricMs must have length 2');
   final eccLow = _ensureNum(eccentric[0], 'metrics.tempo.eccentricMs[0]');
@@ -84,6 +118,7 @@ void validateRuleMap(Map<String, dynamic> m) {
   expect(eccLow <= eccHigh,
       'metrics.tempo.eccentricMs lower bound must be <= upper bound');
 
+  expect(tempo.containsKey('ratio'), 'metrics.tempo.ratio missing');
   final ratio = _ensureList(tempo['ratio'], 'metrics.tempo.ratio');
   expect(ratio.length == 2, 'metrics.tempo.ratio must have length 2');
   final ratioLow = _ensureNum(ratio[0], 'metrics.tempo.ratio[0]');
@@ -92,11 +127,23 @@ void validateRuleMap(Map<String, dynamic> m) {
   expect(ratioLow <= ratioHigh,
       'metrics.tempo.ratio lower bound must be <= upper bound');
 
+  if (tempo.containsKey('concentricMs')) {
+    final concentric = _ensureList(tempo['concentricMs'], 'metrics.tempo.concentricMs');
+    expect(concentric.length == 2,
+        'metrics.tempo.concentricMs must have length 2 when provided');
+    final conLow = _ensureNum(concentric[0], 'metrics.tempo.concentricMs[0]');
+    final conHigh = _ensureNum(concentric[1], 'metrics.tempo.concentricMs[1]');
+    expect(conLow > 0 && conHigh > 0, 'metrics.tempo.concentricMs must be > 0');
+    expect(conLow <= conHigh,
+        'metrics.tempo.concentricMs lower bound must be <= upper bound');
+  }
+
   expect(m.containsKey('scoreWeights'), 'scoreWeights missing');
   final weights = _ensureMap(m['scoreWeights'], 'scoreWeights');
   final requiredWeights = ['form', 'stability', 'tempo'];
   double sum = 0.0;
   for (final key in requiredWeights) {
+    expect(weights.containsKey(key), 'scoreWeights.$key missing');
     final value = _ensureNum(weights[key], 'scoreWeights.$key');
     expect(value >= 0 && value <= 1, 'scoreWeights.$key must be within [0,1]');
     sum += value;


### PR DESCRIPTION
## Summary
- round exported angle values to three decimal places when building angles.csv
- strengthen rule schema validation with explicit key presence checks, numeric finiteness, and strict/relaxed ordering rules

## Testing
- dart test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68da6fe91ba88326b2e038f8526a8267