### PR TITLE
Apply One Euro smoothing to offline angle outputs

### DIFF
--- a/aiwa_milestone_a/lib/pipeline/offline_pipeline.dart
+++ b/aiwa_milestone_a/lib/pipeline/offline_pipeline.dart
@@ -24,18 +24,20 @@ class OfflinePipeline {
     final tMs = frames.map((f) => f.tMs).toList(growable: false);
 
     final filteredPts = _filterKeypoints(frames);
-    final angles = _computeAngles(filteredPts);
+    final rawAngles = _computeAngles(filteredPts);
 
-    final hasAnyKnee = angles.kneeL.any((v) => v != null) ||
-        angles.kneeR.any((v) => v != null);
+    final hasAnyKnee = rawAngles.kneeL.any((v) => v != null) ||
+        rawAngles.kneeR.any((v) => v != null);
     if (!hasAnyKnee) {
       throw AngleComputeFailed('No valid knee angles available for analysis.');
     }
 
-    final hasTrunk = angles.trunk.any((v) => v != null);
+    final hasTrunk = rawAngles.trunk.any((v) => v != null);
     if (!hasTrunk) {
       throw AngleComputeFailed('No valid trunk angles available for analysis.');
     }
+
+    final angles = _smoothAngles(tMs, rawAngles);
 
     final rows = <List<num?>>[];
     for (var i = 0; i < frames.length; i++) {
@@ -549,6 +551,46 @@ double _average(List<double> values) {
   return sum / values.length;
 }
 
+({List<double?> kneeL, List<double?> kneeR, List<double?> trunk}) _smoothAngles(
+  List<int> tMs,
+  ({List<double?> kneeL, List<double?> kneeR, List<double?> trunk}) raw,
+) {
+  final kneeL = <double?>[];
+  final kneeR = <double?>[];
+  final trunk = <double?>[];
+
+  final kneeLFilter = OneEuroFilter();
+  final kneeRFilter = OneEuroFilter();
+  final trunkFilter = OneEuroFilter();
+
+  for (var i = 0; i < tMs.length; i++) {
+    final tSec = tMs[i] / 1000.0;
+
+    final left = raw.kneeL[i];
+    if (left != null) {
+      kneeL.add(kneeLFilter.filter(tSec, left));
+    } else {
+      kneeL.add(null);
+    }
+
+    final right = raw.kneeR[i];
+    if (right != null) {
+      kneeR.add(kneeRFilter.filter(tSec, right));
+    } else {
+      kneeR.add(null);
+    }
+
+    final trunkValue = raw.trunk[i];
+    if (trunkValue != null) {
+      trunk.add(trunkFilter.filter(tSec, trunkValue));
+    } else {
+      trunk.add(null);
+    }
+  }
+
+  return (kneeL: kneeL, kneeR: kneeR, trunk: trunk);
+}
+
 ({List<double?> kneeL, List<double?> kneeR, List<double?> trunk}) _computeAngles(
     List<List<List<double>>> filteredPts) {
   final kneeL = <double?>[];
@@ -574,7 +616,7 @@ double? _kneeAngle(List<List<double>> pts, int hipIdx, int kneeIdx, int ankleIdx
   final knee = V2(pts[kneeIdx][0], pts[kneeIdx][1]);
   final ankle = V2(pts[ankleIdx][0], pts[ankleIdx][1]);
   try {
-    return round1(angleABC(hip, knee, ankle));
+    return angleABC(hip, knee, ankle);
   } catch (_) {
     return null;
   }
@@ -616,10 +658,10 @@ double? _trunkAngle(List<List<double>> pts) {
   final left = single(L_SHOULDER, L_HIP_IDX);
   final right = single(R_SHOULDER, R_HIP_IDX);
   if (left != null && right != null) {
-    return round1((left + right) / 2.0);
+    return (left + right) / 2.0;
   }
   final value = left ?? right;
-  return value == null ? null : round1(value);
+  return value;
 }
 
 double _angleFromVertical(V2 v) {


### PR DESCRIPTION
## Summary
- add a One Euro smoothing pass for knee and trunk angle series in the offline pipeline
- keep raw precision from the knee and trunk angle helpers so the smoother receives unsnapped values

## Testing
- not run (Dart SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68db54296408832691e62c5467eb6db6