### PR TITLE
Align One Euro smoothing timeline with FPS

### DIFF
--- a/aiwa_milestone_a/lib/pipeline/offline_pipeline.dart
+++ b/aiwa_milestone_a/lib/pipeline/offline_pipeline.dart
@@ -24,18 +24,20 @@ class OfflinePipeline {
     final tMs = frames.map((f) => f.tMs).toList(growable: false);
 
     final filteredPts = _filterKeypoints(frames);
-    final angles = _computeAngles(filteredPts);
+    final rawAngles = _computeAngles(filteredPts);
 
-    final hasAnyKnee = angles.kneeL.any((v) => v != null) ||
-        angles.kneeR.any((v) => v != null);
+    final hasAnyKnee = rawAngles.kneeL.any((v) => v != null) ||
+        rawAngles.kneeR.any((v) => v != null);
     if (!hasAnyKnee) {
       throw AngleComputeFailed('No valid knee angles available for analysis.');
     }
 
-    final hasTrunk = angles.trunk.any((v) => v != null);
+    final hasTrunk = rawAngles.trunk.any((v) => v != null);
     if (!hasTrunk) {
       throw AngleComputeFailed('No valid trunk angles available for analysis.');
     }
+
+    final angles = _smoothAngles(kp.fps, rawAngles);
 
     final rows = <List<num?>>[];
     for (var i = 0; i < frames.length; i++) {
@@ -196,12 +198,13 @@ class OfflinePipeline {
 
     final weights = rules.scoreWeights;
     final scores = repMetrics.isEmpty
-        ? {
-            'overall': 0.0,
-            'form': 0.0,
-            'stability': 0.0,
-            'tempo': 0.0,
-          }
+        ? _computeScoresNoReps(
+            mainKnee: mainKnee,
+            trunk: angles.trunk,
+            trunkThreshold:
+                strictness == Strictness.strict ? trunkStrict : trunkRelaxed,
+            weights: weights,
+          )
         : _computeScores(
             repMetrics: repMetrics,
             depthStrict: depthStrict,
@@ -483,6 +486,52 @@ Map<String, double> _computeScores({
   };
 }
 
+Map<String, double> _computeScoresNoReps({
+  required List<double?> mainKnee,
+  required List<double?> trunk,
+  required double trunkThreshold,
+  required Map<String, num> weights,
+}) {
+  final trunkValues = trunk.whereType<double>().toList();
+  final maxTrunk = trunkValues.isEmpty
+      ? 0.0
+      : trunkValues.reduce((a, b) => a > b ? a : b);
+  final trunkDeficit = math.max(0.0, maxTrunk - trunkThreshold);
+  // Without detected reps we cannot measure depth coverage against valleys, so
+  // the depth component stays neutral while trunk lean still reduces the form
+  // score, matching the baseline fallback behavior.
+  final form = _clampScore(100.0 - (trunkDeficit * 1.5));
+
+  final kneeValues = mainKnee.whereType<double>().toList();
+  double stabilityPenalty = 0.0;
+  if (mainKnee.length >= 5 && kneeValues.isNotEmpty) {
+    final mean = kneeValues.reduce((a, b) => a + b) / kneeValues.length;
+    final variance = kneeValues
+            .map((v) => (v - mean) * (v - mean))
+            .reduce((a, b) => a + b) /
+        kneeValues.length;
+    final stdDev = math.sqrt(variance);
+    stabilityPenalty = stdDev * 2.0;
+  }
+  final stability = _clampScore(100.0 - stabilityPenalty);
+
+  // No repetitions means no tempo measurement; treat as perfect tempo per
+  // baseline behavior.
+  const tempo = 100.0;
+
+  double weight(String key) => (weights[key] ?? 0).toDouble();
+  final overall = form * weight('form') +
+      stability * weight('stability') +
+      tempo * weight('tempo');
+
+  return {
+    'form': _roundScore(form),
+    'stability': _roundScore(stability),
+    'tempo': _roundScore(tempo),
+    'overall': _roundScore(overall),
+  };
+}
+
 double _roundScore(double value) => ((value * 10).roundToDouble()) / 10.0;
 
 double _scoreFromBounds({
@@ -549,6 +598,52 @@ double _average(List<double> values) {
   return sum / values.length;
 }
 
+({List<double?> kneeL, List<double?> kneeR, List<double?> trunk}) _smoothAngles(
+  double fps,
+  ({List<double?> kneeL, List<double?> kneeR, List<double?> trunk}) raw,
+) {
+  final kneeL = <double?>[];
+  final kneeR = <double?>[];
+  final trunk = <double?>[];
+
+  final step = 1.0 / fps;
+  var kneeLT = 0.0;
+  var kneeRT = 0.0;
+  var trunkT = 0.0;
+
+  final kneeLFilter = OneEuroFilter(minCutoff: 1.0, beta: 0.005, dCutoff: 1.0);
+  final kneeRFilter = OneEuroFilter(minCutoff: 1.0, beta: 0.005, dCutoff: 1.0);
+  final trunkFilter = OneEuroFilter(minCutoff: 1.0, beta: 0.005, dCutoff: 1.0);
+
+  for (var i = 0; i < raw.kneeL.length; i++) {
+    final left = raw.kneeL[i];
+    if (left != null) {
+      kneeL.add(kneeLFilter.filter(kneeLT, left));
+      kneeLT += step;
+    } else {
+      kneeL.add(null);
+    }
+
+    final right = raw.kneeR[i];
+    if (right != null) {
+      kneeR.add(kneeRFilter.filter(kneeRT, right));
+      kneeRT += step;
+    } else {
+      kneeR.add(null);
+    }
+
+    final trunkValue = raw.trunk[i];
+    if (trunkValue != null) {
+      trunk.add(trunkFilter.filter(trunkT, trunkValue));
+      trunkT += step;
+    } else {
+      trunk.add(null);
+    }
+  }
+
+  return (kneeL: kneeL, kneeR: kneeR, trunk: trunk);
+}
+
 ({List<double?> kneeL, List<double?> kneeR, List<double?> trunk}) _computeAngles(
     List<List<List<double>>> filteredPts) {
   final kneeL = <double?>[];
@@ -574,7 +669,7 @@ double? _kneeAngle(List<List<double>> pts, int hipIdx, int kneeIdx, int ankleIdx
   final knee = V2(pts[kneeIdx][0], pts[kneeIdx][1]);
   final ankle = V2(pts[ankleIdx][0], pts[ankleIdx][1]);
   try {
-    return round1(angleABC(hip, knee, ankle));
+    return angleABC(hip, knee, ankle);
   } catch (_) {
     return null;
   }
@@ -616,10 +711,10 @@ double? _trunkAngle(List<List<double>> pts) {
   final left = single(L_SHOULDER, L_HIP_IDX);
   final right = single(R_SHOULDER, R_HIP_IDX);
   if (left != null && right != null) {
-    return round1((left + right) / 2.0);
+    return (left + right) / 2.0;
   }
   final value = left ?? right;
-  return value == null ? null : round1(value);
+  return value;
 }
 
 double _angleFromVertical(V2 v) {


### PR DESCRIPTION
## Summary
- feed the One Euro filters with fps-derived timestamps so null frames do not inflate dt
- instantiate filters with the spec parameters while keeping downstream consumers unchanged
- align the zero-rep score fallback with the baseline trunk/stability aggregation so overall/form/stability/tempo stay graded

## Testing
- `dart test test/golden_compare_test.dart` *(fails: `dart` unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_b_68db54296408832691e62c5467eb6db6