### PR TITLE
Add frame streamer and neutral keypoint export

### DIFF
--- a/aiwa_milestone_a/bin/aiwa_cli.dart
+++ b/aiwa_milestone_a/bin/aiwa_cli.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:args/args.dart';
+import 'package:path/path.dart' as p;
 
 import 'package:aiwa_milestone_a/core/io.dart'; // 提供 jsonPretty
 import 'package:aiwa_milestone_a/spec/rule_parser.dart';
@@ -21,7 +22,9 @@ void main(List<String> args) async {
     ..addOption('strictness',
         defaultsTo: 'relaxed', allowed: ['relaxed', 'strict'])
     ..addOption('out',
-        abbr: 'o', help: 'Output dir', defaultsTo: 'build/offline_out');
+        abbr: 'o', help: 'Output dir', defaultsTo: 'build/offline_out')
+    ..addOption('video',
+        help: 'Path to original video (used for naming outputs)');
   final opts = p.parse(args);
 
   try {
@@ -35,7 +38,12 @@ void main(List<String> args) async {
 
     final out = await pipeline.run(kp);
 
-    final outDir = Directory(opts['out'])..createSync(recursive: true);
+    final baseName = opts['video'] != null
+        ? p.basenameWithoutExtension(opts['video'])
+        : p.basenameWithoutExtension(opts['keypoints']);
+
+    final outDir = Directory(p.join(opts['out'], baseName))
+      ..createSync(recursive: true);
     await File('${outDir.path}/angles.csv').writeAsString(out.anglesCsv);
     await File('${outDir.path}/result.json')
       .writeAsString(jsonPretty(out.resultJson));

--- a/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
+++ b/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
@@ -76,8 +76,6 @@ List<NeutralKeypoint> adaptMlKitPose({
   required bool returnEmptyWhenLow,
 }) {
   final List<NeutralKeypoint> out = [];
-  const double defaultScore = 1.0; // 新版 ML Kit 无 inFrameLikelihood，统一置 1.0
-
   final int w = (width <= 0) ? 1 : width;
   final int h = (height <= 0) ? 1 : height;
 
@@ -86,7 +84,7 @@ List<NeutralKeypoint> adaptMlKitPose({
     if (neutralName == null) return;
 
     // 统一默认置信度
-    final double s = defaultScore;
+    final double s = landmark.likelihood.clamp(0.0, 1.0).toDouble();
     if (s < minScore) return;
 
     out.add(NeutralKeypoint(
@@ -112,7 +110,7 @@ List<NeutralKeypoint> adaptMlKitPose({
         x: (landmark.x / w).clamp(0.0, 1.0),
         y: (landmark.y / h).clamp(0.0, 1.0),
         z: keepZ ? landmark.z : null,
-        score: defaultScore,
+        score: landmark.likelihood.clamp(0.0, 1.0).toDouble(),
       ));
     });
   }

--- a/aiwa_milestone_a/lib/pose/frame_streamer.dart
+++ b/aiwa_milestone_a/lib/pose/frame_streamer.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'pose_engine.dart';
+
+class RawImageFrame {
+  final Uint8List bytes;
+  final int width;
+  final int height;
+  final int rotationDeg;
+
+  const RawImageFrame({
+    required this.bytes,
+    required this.width,
+    required this.height,
+    this.rotationDeg = 0,
+  });
+}
+
+class FrameStreamerConfig {
+  final double fps;
+  final int stride;
+  final bool mirror;
+  final String engineName;
+  final String modelName;
+  final String sdkVersion;
+  final String videoBasename;
+
+  const FrameStreamerConfig({
+    required this.engineName,
+    required this.modelName,
+    required this.sdkVersion,
+    required this.videoBasename,
+    this.fps = 30.0,
+    this.stride = 2,
+    this.mirror = true,
+  })  : assert(fps > 0),
+        assert(stride > 0);
+
+  double get effectiveFps => fps / stride;
+}
+
+class FrameStreamResult {
+  final FrameStreamerConfig config;
+  final List<NeutralFrame> frames;
+  final int width;
+  final int height;
+  final double frameIntervalMs;
+
+  const FrameStreamResult({
+    required this.config,
+    required this.frames,
+    required this.width,
+    required this.height,
+    required this.frameIntervalMs,
+  });
+
+  int get durationMs =>
+      frames.isEmpty ? 0 : frames.last.timestampMs.round();
+
+  Map<String, dynamic> toNeutralKeypointsJson() => {
+        'version': 'vB1.1',
+        'video': {
+          'fpsIntended': config.fps,
+          'width': width,
+          'height': height,
+          'durationMs': durationMs,
+        },
+        'engine': {
+          'name': config.engineName,
+          'model': config.modelName,
+          'sdkVersion': config.sdkVersion,
+        },
+        'sampling': {
+          'stride': config.stride,
+          'effectiveFps': config.effectiveFps,
+        },
+        'frames': frames.map((f) => f.toJson()).toList(),
+      };
+}
+
+class FrameStreamer {
+  final PoseEngine _engine;
+  final PoseEngineConfig _engineConfig;
+  final FrameStreamerConfig _config;
+
+  FrameStreamer({
+    required PoseEngine engine,
+    required PoseEngineConfig engineConfig,
+    required FrameStreamerConfig config,
+  })  : _engine = engine,
+        _engineConfig = engineConfig,
+        _config = config;
+
+  Future<FrameStreamResult> run(Stream<RawImageFrame> frameStream) async {
+    await _engine.init(_engineConfig);
+
+    final outputs = <NeutralFrame>[];
+    int? firstWidth;
+    int? firstHeight;
+    var processedIndex = 0;
+    var sourceIndex = 0;
+    final frameIntervalMs = 1000.0 * _config.stride / _config.fps;
+
+    try {
+      await for (final raw in frameStream) {
+        final currentSource = sourceIndex;
+        sourceIndex++;
+
+        firstWidth ??= raw.width;
+        firstHeight ??= raw.height;
+
+        if (currentSource % _config.stride != 0) {
+          continue;
+        }
+
+        final frame = await _engine.infer(PoseEngineInput(
+          imageBytes: raw.bytes,
+          width: raw.width,
+          height: raw.height,
+          rotationDeg: raw.rotationDeg,
+          frameIndex: processedIndex,
+          timestampMs: processedIndex * frameIntervalMs,
+          mirrorHorizontally: _config.mirror,
+        ));
+
+        outputs.add(frame);
+        processedIndex++;
+      }
+    } finally {
+      await _engine.close();
+    }
+
+    return FrameStreamResult(
+      config: _config,
+      frames: outputs,
+      width: firstWidth ?? 0,
+      height: firstHeight ?? 0,
+      frameIntervalMs: frameIntervalMs,
+    );
+  }
+}

--- a/aiwa_milestone_a/lib/pose/mlkit_pose_engine.dart
+++ b/aiwa_milestone_a/lib/pose/mlkit_pose_engine.dart
@@ -85,6 +85,8 @@ class MlKitPoseEngine implements PoseEngine {
         width: input.width,
         height: input.height,
         keypoints: const [],
+        lowConfidence: true,
+        mirrorApplied: input.mirrorHorizontally,
       );
     }
 
@@ -97,13 +99,31 @@ class MlKitPoseEngine implements PoseEngine {
       minScore: _config.minScore,
       returnEmptyWhenLow: _config.returnEmptyWhenLow,
     );
+    final processed = input.mirrorHorizontally
+        ? keypoints
+            .map((kp) =>
+                kp.copyWith(x: (1.0 - kp.x).clamp(0.0, 1.0).toDouble()))
+            .toList(growable: false)
+        : keypoints;
+
+    final totalCount = processed.length;
+    final highConfidenceCount =
+        processed.where((kp) => kp.score >= 0.5).length;
+    final filtered =
+        processed.where((kp) => kp.score >= 0.3).toList(growable: false);
+
+    final bool lowConfidence = totalCount == 0
+        ? true
+        : (highConfidenceCount / totalCount) < 0.7;
 
     return NeutralFrame(
       frameIndex: input.frameIndex,
       timestampMs: input.timestampMs,
       width: input.width,
       height: input.height,
-      keypoints: keypoints,
+      keypoints: filtered,
+      lowConfidence: lowConfidence,
+      mirrorApplied: input.mirrorHorizontally,
     );
   }
 

--- a/aiwa_milestone_a/lib/pose/pose_engine.dart
+++ b/aiwa_milestone_a/lib/pose/pose_engine.dart
@@ -10,11 +10,11 @@ import 'dart:typed_data';
 
 /// 中立关键点：统一名称 + 归一化坐标 + 置信度 + 可选深度
 class NeutralKeypoint {
-  final String name;   // 例如 nose、leftHip、rightKnee 等
-  final double x;      // 归一化到 [0,1]，相对于帧宽
-  final double y;      // 归一化到 [0,1]，相对于帧高（注意坐标系：屏幕/图像坐标）
-  final double? z;     // 可选（ML Kit 提供实验性 Z）
-  final double score;  // 置信度 [0,1]
+  final String name; // 例如 nose、leftHip、rightKnee 等
+  final double x; // 归一化到 [0,1]，相对于帧宽
+  final double y; // 归一化到 [0,1]，相对于帧高（注意坐标系：屏幕/图像坐标）
+  final double? z; // 可选（ML Kit 提供实验性 Z）
+  final double score; // 置信度 [0,1]
 
   const NeutralKeypoint({
     required this.name,
@@ -23,6 +23,21 @@ class NeutralKeypoint {
     required this.score,
     this.z,
   });
+
+  NeutralKeypoint copyWith({
+    double? x,
+    double? y,
+    double? score,
+    double? z,
+  }) {
+    return NeutralKeypoint(
+      name: name,
+      x: x ?? this.x,
+      y: y ?? this.y,
+      score: score ?? this.score,
+      z: z ?? this.z,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
         'name': name,
@@ -35,11 +50,13 @@ class NeutralKeypoint {
 
 /// 单帧中立关键点及其时间/尺寸信息（便于导出与离线管线使用）
 class NeutralFrame {
-  final int frameIndex;      // 序号（从 0 递增）
-  final double timestampMs;  // 该帧时间戳（毫秒）
-  final int width;           // 原始帧宽（像素）
-  final int height;          // 原始帧高（像素）
+  final int frameIndex; // 序号（从 0 递增）
+  final double timestampMs; // 该帧时间戳（毫秒）
+  final int width; // 原始帧宽（像素）
+  final int height; // 原始帧高（像素）
   final List<NeutralKeypoint> keypoints;
+  final bool lowConfidence; // 当前帧是否低置信
+  final bool mirrorApplied; // 是否进行了镜像翻转
 
   const NeutralFrame({
     required this.frameIndex,
@@ -47,13 +64,15 @@ class NeutralFrame {
     required this.width,
     required this.height,
     required this.keypoints,
+    this.lowConfidence = false,
+    this.mirrorApplied = false,
   });
 
   Map<String, dynamic> toJson() => {
         'frameIndex': frameIndex,
-        'timestampMs': timestampMs,
-        'width': width,
-        'height': height,
+        'timestampMs': timestampMs.round(),
+        'lowConfidence': lowConfidence,
+        'mirrorApplied': mirrorApplied,
         'keypoints': keypoints.map((e) => e.toJson()).toList(),
       };
 }
@@ -83,6 +102,7 @@ class PoseEngineInput {
   final int rotationDeg; // 图像旋转角（如相机传感器方向）
   final int frameIndex;
   final double timestampMs;
+  final bool mirrorHorizontally;
 
   PoseEngineInput({
     required this.width,
@@ -91,6 +111,7 @@ class PoseEngineInput {
     required this.timestampMs,
     this.imageBytes,
     this.rotationDeg = 0,
+    this.mirrorHorizontally = false,
   });
 }
 

--- a/aiwa_milestone_a/lib/result/neutral_keypoints_export.dart
+++ b/aiwa_milestone_a/lib/result/neutral_keypoints_export.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import '../pose/frame_streamer.dart';
+
+Future<File> writeNeutralKeypointsJson({
+  required FrameStreamResult result,
+  required Directory outputRoot,
+  bool pretty = true,
+}) async {
+  final outDir = Directory(
+    p.join(outputRoot.path, result.config.videoBasename),
+  );
+  if (!outDir.existsSync()) {
+    outDir.createSync(recursive: true);
+  }
+
+  final file = File(p.join(outDir.path, 'neutral_keypoints.json'));
+  final encoder =
+      pretty ? const JsonEncoder.withIndent('  ') : const JsonEncoder();
+  final jsonStr = encoder.convert(result.toNeutralKeypointsJson());
+  await file.writeAsString(jsonStr);
+  return file;
+}


### PR DESCRIPTION
## Summary
- add a frame streaming runner that samples frames, drives the ML Kit pose engine, and produces Milestone B neutral keypoint metadata
- normalize pose adapter scoring, add mirroring/low-confidence filtering in the ML Kit engine, and expose metadata required by the schema
- write neutral_keypoints.json alongside existing outputs and nest CLI results under the video basename

## Testing
- not run (dart/flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68ec5c7316b083269a831ebfc400c903