### PR TITLE
Fix ML Kit adapter compatibility and CLI parser alias

### DIFF
--- a/aiwa_milestone_a/bin/aiwa_cli.dart
+++ b/aiwa_milestone_a/bin/aiwa_cli.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:args/args.dart';
+import 'package:path/path.dart' as path;
 
 import 'package:aiwa_milestone_a/core/io.dart'; // 提供 jsonPretty
 import 'package:aiwa_milestone_a/spec/rule_parser.dart';
@@ -9,7 +10,7 @@ import 'package:aiwa_milestone_a/pose/kp_models.dart';
 
 
 void main(List<String> args) async {
-  final p = ArgParser()
+  final parser = ArgParser()
     ..addOption('keypoints',
         abbr: 'k',
         help: 'Path to kp.json',
@@ -21,8 +22,10 @@ void main(List<String> args) async {
     ..addOption('strictness',
         defaultsTo: 'relaxed', allowed: ['relaxed', 'strict'])
     ..addOption('out',
-        abbr: 'o', help: 'Output dir', defaultsTo: 'build/offline_out');
-  final opts = p.parse(args);
+        abbr: 'o', help: 'Output dir', defaultsTo: 'build/offline_out')
+    ..addOption('video',
+        help: 'Path to original video (used for naming outputs)');
+  final opts = parser.parse(args);
 
   try {
     final kpStr = await File(opts['keypoints']).readAsString();
@@ -30,12 +33,20 @@ void main(List<String> args) async {
     final ruleStr = await File(opts['rule']).readAsString();
     final rs = parseRuleSet(ruleStr);
 
-    final pipeline = OfflinePipeline(rs,
-      opts['strictness']=='strict' ? Strictness.strict : Strictness.relaxed);
+    final pipeline = OfflinePipeline(
+        rs,
+        opts['strictness'] == 'strict'
+            ? Strictness.strict
+            : Strictness.relaxed);
 
     final out = await pipeline.run(kp);
 
-    final outDir = Directory(opts['out'])..createSync(recursive: true);
+    final baseName = opts['video'] != null
+        ? path.basenameWithoutExtension(opts['video'])
+        : path.basenameWithoutExtension(opts['keypoints']);
+
+    final outDir = Directory(path.join(opts['out'], baseName))
+      ..createSync(recursive: true);
     await File('${outDir.path}/angles.csv').writeAsString(out.anglesCsv);
     await File('${outDir.path}/result.json')
       .writeAsString(jsonPretty(out.resultJson));

--- a/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
+++ b/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
@@ -115,15 +115,54 @@ double? _extractLikelihood(PoseLandmark landmark) {
   return null;
 }
 
-Iterable<PoseLandmark> _iterableLandmarks(Pose pose) {
+Map<PoseLandmarkType, PoseLandmark> _landmarksByType(Pose pose) {
   final dynamic rawLandmarks = pose.landmarks;
-  if (rawLandmarks is Iterable<PoseLandmark>) {
+  if (rawLandmarks is Map<PoseLandmarkType, PoseLandmark>) {
     return rawLandmarks;
   }
-  if (rawLandmarks is Map<Object?, PoseLandmark>) {
-    return rawLandmarks.values;
+
+  if (rawLandmarks is Map) {
+    final result = <PoseLandmarkType, PoseLandmark>{};
+    for (final entry in rawLandmarks.entries) {
+      final dynamic key = entry.key;
+      final dynamic value = entry.value;
+
+      PoseLandmark? landmark;
+      if (value is PoseLandmark) {
+        landmark = value;
+      } else if (key is PoseLandmark) {
+        landmark = key;
+      }
+
+      if (landmark == null) {
+        continue;
+      }
+
+      final PoseLandmarkType? type =
+          key is PoseLandmarkType ? key : landmark.type;
+      if (type != null) {
+        result[type] = landmark;
+      }
+    }
+    if (result.isNotEmpty) {
+      return result;
+    }
   }
-  return const <PoseLandmark>[];
+
+  if (rawLandmarks is Iterable<PoseLandmark>) {
+    return {
+      for (final landmark in rawLandmarks) landmark.type: landmark,
+    };
+  }
+
+  if (rawLandmarks is Iterable) {
+    return {
+      for (final item in rawLandmarks)
+        if (item is PoseLandmark) item.type: item,
+    };
+  }
+
+  return <PoseLandmarkType, PoseLandmark>{};
 }
 
 double _clampUnit(num value) => value.clamp(0.0, 1.0).toDouble();
@@ -144,9 +183,8 @@ List<NeutralKeypoint> adaptMlKitPose({
   final int w = (width <= 0) ? 1 : width;
   final int h = (height <= 0) ? 1 : height;
 
-  final Map<PoseLandmarkType, PoseLandmark> landmarksByType = {
-    for (final landmark in pose.landmarks) landmark.type: landmark,
-  };
+  final Map<PoseLandmarkType, PoseLandmark> landmarksByType =
+      _landmarksByType(pose);
 
   for (final type in _mlkitLandmarkOrder) {
     final landmark = landmarksByType[type];
@@ -182,6 +220,7 @@ List<NeutralKeypoint> adaptMlKitPose({
         x: _clampUnit(landmark.x / w),
         y: _clampUnit(landmark.y / h),
         z: keepZ ? landmark.z : null,
+        
         score: _clampUnit(_extractLikelihood(landmark) ?? 1.0),
       ));
     }

--- a/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
+++ b/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
@@ -99,7 +99,7 @@ const List<PoseLandmarkType> _mlkitLandmarkOrder = [
   PoseLandmarkType.rightFootIndex,
 ];
 
-const int kMlKitNeutralKeypointCount = _mlkitLandmarkOrder.length;
+const int kMlKitNeutralKeypointCount = 33;
 
 double? _extractLikelihood(PoseLandmark landmark) {
   final dynamic dynamicLandmark = landmark;
@@ -114,6 +114,58 @@ double? _extractLikelihood(PoseLandmark landmark) {
   }
   return null;
 }
+
+Map<PoseLandmarkType, PoseLandmark> _landmarksByType(Pose pose) {
+  final dynamic rawLandmarks = pose.landmarks;
+  if (rawLandmarks is Map<PoseLandmarkType, PoseLandmark>) {
+    return rawLandmarks;
+  }
+
+  if (rawLandmarks is Map) {
+    final result = <PoseLandmarkType, PoseLandmark>{};
+    for (final entry in rawLandmarks.entries) {
+      final dynamic key = entry.key;
+      final dynamic value = entry.value;
+
+      PoseLandmark? landmark;
+      if (value is PoseLandmark) {
+        landmark = value;
+      } else if (key is PoseLandmark) {
+        landmark = key;
+      }
+
+      if (landmark == null) {
+        continue;
+      }
+
+      final PoseLandmarkType? type =
+          key is PoseLandmarkType ? key : landmark.type;
+      if (type != null) {
+        result[type] = landmark;
+      }
+    }
+    if (result.isNotEmpty) {
+      return result;
+    }
+  }
+
+  if (rawLandmarks is Iterable<PoseLandmark>) {
+    return {
+      for (final landmark in rawLandmarks) landmark.type: landmark,
+    };
+  }
+
+  if (rawLandmarks is Iterable) {
+    return {
+      for (final item in rawLandmarks)
+        if (item is PoseLandmark) item.type: item,
+    };
+  }
+
+  return <PoseLandmarkType, PoseLandmark>{};
+}
+
+double _clampUnit(num value) => value.clamp(0.0, 1.0).toDouble();
 
 /// 将 ML Kit 的 Pose → List<NeutralKeypoint>
 /// - 会做坐标归一化（x/width, y/height）
@@ -131,22 +183,25 @@ List<NeutralKeypoint> adaptMlKitPose({
   final int w = (width <= 0) ? 1 : width;
   final int h = (height <= 0) ? 1 : height;
 
+  final Map<PoseLandmarkType, PoseLandmark> landmarksByType =
+      _landmarksByType(pose);
+
   for (final type in _mlkitLandmarkOrder) {
-    final landmark = pose.landmarks[type];
+    final landmark = landmarksByType[type];
     if (landmark == null) continue;
 
     final neutralName = _mlkitTypeToNeutralName[type];
     if (neutralName == null) continue;
 
-    final double s = (_extractLikelihood(landmark) ?? 1.0).clamp(0.0, 1.0);
+    final double s = _clampUnit(_extractLikelihood(landmark) ?? 1.0);
     if (s < minScore) {
       continue;
     }
 
     out.add(NeutralKeypoint(
       name: neutralName,
-      x: (landmark.x / w).clamp(0.0, 1.0),
-      y: (landmark.y / h).clamp(0.0, 1.0),
+      x: _clampUnit(landmark.x / w),
+      y: _clampUnit(landmark.y / h),
       z: keepZ ? landmark.z : null,
       score: s,
     ));
@@ -154,7 +209,7 @@ List<NeutralKeypoint> adaptMlKitPose({
 
   if (out.isEmpty && !returnEmptyWhenLow) {
     for (final type in _mlkitLandmarkOrder) {
-      final landmark = pose.landmarks[type];
+      final landmark = landmarksByType[type];
       if (landmark == null) continue;
 
       final neutralName = _mlkitTypeToNeutralName[type];
@@ -162,10 +217,10 @@ List<NeutralKeypoint> adaptMlKitPose({
 
       out.add(NeutralKeypoint(
         name: neutralName,
-        x: (landmark.x / w).clamp(0.0, 1.0),
-        y: (landmark.y / h).clamp(0.0, 1.0),
+        x: _clampUnit(landmark.x / w),
+        y: _clampUnit(landmark.y / h),
         z: keepZ ? landmark.z : null,
-        score: (_extractLikelihood(landmark) ?? 1.0).clamp(0.0, 1.0),
+        score: _clampUnit(_extractLikelihood(landmark) ?? 1.0),
       ));
     }
   }

--- a/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
+++ b/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
@@ -131,8 +131,12 @@ List<NeutralKeypoint> adaptMlKitPose({
   final int w = (width <= 0) ? 1 : width;
   final int h = (height <= 0) ? 1 : height;
 
+  final Map<PoseLandmarkType, PoseLandmark> landmarksByType = {
+    for (final landmark in pose.landmarks) landmark.type: landmark,
+  };
+
   for (final type in _mlkitLandmarkOrder) {
-    final landmark = pose.landmarks[type];
+    final landmark = landmarksByType[type];
     if (landmark == null) continue;
 
     final neutralName = _mlkitTypeToNeutralName[type];
@@ -154,7 +158,7 @@ List<NeutralKeypoint> adaptMlKitPose({
 
   if (out.isEmpty && !returnEmptyWhenLow) {
     for (final type in _mlkitLandmarkOrder) {
-      final landmark = pose.landmarks[type];
+      final landmark = landmarksByType[type];
       if (landmark == null) continue;
 
       final neutralName = _mlkitTypeToNeutralName[type];

--- a/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
+++ b/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
@@ -63,6 +63,58 @@ const Map<PoseLandmarkType, String> _mlkitTypeToNeutralName = {
   PoseLandmarkType.rightFootIndex: 'rightFootIndex',
 };
 
+const List<PoseLandmarkType> _mlkitLandmarkOrder = [
+  PoseLandmarkType.nose,
+  PoseLandmarkType.leftEyeInner,
+  PoseLandmarkType.leftEye,
+  PoseLandmarkType.leftEyeOuter,
+  PoseLandmarkType.rightEyeInner,
+  PoseLandmarkType.rightEye,
+  PoseLandmarkType.rightEyeOuter,
+  PoseLandmarkType.leftEar,
+  PoseLandmarkType.rightEar,
+  PoseLandmarkType.leftMouth,
+  PoseLandmarkType.rightMouth,
+  PoseLandmarkType.leftShoulder,
+  PoseLandmarkType.rightShoulder,
+  PoseLandmarkType.leftElbow,
+  PoseLandmarkType.rightElbow,
+  PoseLandmarkType.leftWrist,
+  PoseLandmarkType.rightWrist,
+  PoseLandmarkType.leftPinky,
+  PoseLandmarkType.rightPinky,
+  PoseLandmarkType.leftIndex,
+  PoseLandmarkType.rightIndex,
+  PoseLandmarkType.leftThumb,
+  PoseLandmarkType.rightThumb,
+  PoseLandmarkType.leftHip,
+  PoseLandmarkType.rightHip,
+  PoseLandmarkType.leftKnee,
+  PoseLandmarkType.rightKnee,
+  PoseLandmarkType.leftAnkle,
+  PoseLandmarkType.rightAnkle,
+  PoseLandmarkType.leftHeel,
+  PoseLandmarkType.rightHeel,
+  PoseLandmarkType.leftFootIndex,
+  PoseLandmarkType.rightFootIndex,
+];
+
+const int kMlKitNeutralKeypointCount = _mlkitLandmarkOrder.length;
+
+double? _extractLikelihood(PoseLandmark landmark) {
+  final dynamic dynamicLandmark = landmark;
+  try {
+    final value = dynamicLandmark.likelihood;
+    if (value is num) {
+      return value.toDouble();
+    }
+  } catch (_) {
+    // google_mlkit_pose_detection 0.14.0 移除了公开的 inFrameLikelihood，
+    // 通过 dynamic 访问以兼容不同版本；若不存在则返回 null。
+  }
+  return null;
+}
+
 /// 将 ML Kit 的 Pose → List<NeutralKeypoint>
 /// - 会做坐标归一化（x/width, y/height）
 /// - 可选筛除低置信度点
@@ -76,18 +128,20 @@ List<NeutralKeypoint> adaptMlKitPose({
   required bool returnEmptyWhenLow,
 }) {
   final List<NeutralKeypoint> out = [];
-  const double defaultScore = 1.0; // 新版 ML Kit 无 inFrameLikelihood，统一置 1.0
-
   final int w = (width <= 0) ? 1 : width;
   final int h = (height <= 0) ? 1 : height;
 
-  void emit(PoseLandmarkType type, PoseLandmark landmark) {
-    final neutralName = _mlkitTypeToNeutralName[type];
-    if (neutralName == null) return;
+  for (final type in _mlkitLandmarkOrder) {
+    final landmark = pose.landmarks[type];
+    if (landmark == null) continue;
 
-    // 统一默认置信度
-    final double s = defaultScore;
-    if (s < minScore) return;
+    final neutralName = _mlkitTypeToNeutralName[type];
+    if (neutralName == null) continue;
+
+    final double s = (_extractLikelihood(landmark) ?? 1.0).clamp(0.0, 1.0);
+    if (s < minScore) {
+      continue;
+    }
 
     out.add(NeutralKeypoint(
       name: neutralName,
@@ -98,23 +152,22 @@ List<NeutralKeypoint> adaptMlKitPose({
     ));
   }
 
-  // 第一轮：按 minScore 过滤（虽然默认 1.0 基本不过滤，但保留接口一致性）
-  pose.landmarks.forEach(emit);
-
-  // 可选 fail-soft：若被过滤为空且不允许空，放宽返回全部点（score 仍为 1.0）
   if (out.isEmpty && !returnEmptyWhenLow) {
-    pose.landmarks.forEach((type, landmark) {
+    for (final type in _mlkitLandmarkOrder) {
+      final landmark = pose.landmarks[type];
+      if (landmark == null) continue;
+
       final neutralName = _mlkitTypeToNeutralName[type];
-      if (neutralName == null) return;
+      if (neutralName == null) continue;
 
       out.add(NeutralKeypoint(
         name: neutralName,
         x: (landmark.x / w).clamp(0.0, 1.0),
         y: (landmark.y / h).clamp(0.0, 1.0),
         z: keepZ ? landmark.z : null,
-        score: defaultScore,
+        score: (_extractLikelihood(landmark) ?? 1.0).clamp(0.0, 1.0),
       ));
-    });
+    }
   }
 
   return out;

--- a/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
+++ b/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
@@ -99,7 +99,7 @@ const List<PoseLandmarkType> _mlkitLandmarkOrder = [
   PoseLandmarkType.rightFootIndex,
 ];
 
-const int kMlKitNeutralKeypointCount = _mlkitLandmarkOrder.length;
+const int kMlKitNeutralKeypointCount = 33;
 
 double? _extractLikelihood(PoseLandmark landmark) {
   final dynamic dynamicLandmark = landmark;
@@ -114,6 +114,30 @@ double? _extractLikelihood(PoseLandmark landmark) {
   }
   return null;
 }
+
+Map<PoseLandmarkType, PoseLandmark> _landmarksByType(Pose pose) {
+  final dynamic rawLandmarks = pose.landmarks;
+  if (rawLandmarks is Map<PoseLandmarkType, PoseLandmark>) {
+    return rawLandmarks;
+  }
+
+  if (rawLandmarks is Iterable<PoseLandmark>) {
+    return {
+      for (final landmark in rawLandmarks) landmark.type: landmark,
+    };
+  }
+
+  if (rawLandmarks is Iterable) {
+    return {
+      for (final item in rawLandmarks)
+        if (item is PoseLandmark) item.type: item,
+    };
+  }
+
+  return <PoseLandmarkType, PoseLandmark>{};
+}
+
+double _clampUnit(num value) => value.clamp(0.0, 1.0).toDouble();
 
 /// 将 ML Kit 的 Pose → List<NeutralKeypoint>
 /// - 会做坐标归一化（x/width, y/height）
@@ -131,22 +155,25 @@ List<NeutralKeypoint> adaptMlKitPose({
   final int w = (width <= 0) ? 1 : width;
   final int h = (height <= 0) ? 1 : height;
 
+  final Map<PoseLandmarkType, PoseLandmark> landmarksByType =
+      _landmarksByType(pose);
+
   for (final type in _mlkitLandmarkOrder) {
-    final landmark = pose.landmarks[type];
+    final landmark = landmarksByType[type];
     if (landmark == null) continue;
 
     final neutralName = _mlkitTypeToNeutralName[type];
     if (neutralName == null) continue;
 
-    final double s = (_extractLikelihood(landmark) ?? 1.0).clamp(0.0, 1.0);
+    final double s = _clampUnit(_extractLikelihood(landmark) ?? 1.0);
     if (s < minScore) {
       continue;
     }
 
     out.add(NeutralKeypoint(
       name: neutralName,
-      x: (landmark.x / w).clamp(0.0, 1.0),
-      y: (landmark.y / h).clamp(0.0, 1.0),
+      x: _clampUnit(landmark.x / w),
+      y: _clampUnit(landmark.y / h),
       z: keepZ ? landmark.z : null,
       score: s,
     ));
@@ -154,7 +181,7 @@ List<NeutralKeypoint> adaptMlKitPose({
 
   if (out.isEmpty && !returnEmptyWhenLow) {
     for (final type in _mlkitLandmarkOrder) {
-      final landmark = pose.landmarks[type];
+      final landmark = landmarksByType[type];
       if (landmark == null) continue;
 
       final neutralName = _mlkitTypeToNeutralName[type];
@@ -162,10 +189,10 @@ List<NeutralKeypoint> adaptMlKitPose({
 
       out.add(NeutralKeypoint(
         name: neutralName,
-        x: (landmark.x / w).clamp(0.0, 1.0),
-        y: (landmark.y / h).clamp(0.0, 1.0),
+        x: _clampUnit(landmark.x / w),
+        y: _clampUnit(landmark.y / h),
         z: keepZ ? landmark.z : null,
-        score: (_extractLikelihood(landmark) ?? 1.0).clamp(0.0, 1.0),
+        score: _clampUnit(_extractLikelihood(landmark) ?? 1.0),
       ));
     }
   }

--- a/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
+++ b/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
@@ -115,6 +115,19 @@ double? _extractLikelihood(PoseLandmark landmark) {
   return null;
 }
 
+Iterable<PoseLandmark> _iterableLandmarks(Pose pose) {
+  final dynamic rawLandmarks = pose.landmarks;
+  if (rawLandmarks is Iterable<PoseLandmark>) {
+    return rawLandmarks;
+  }
+  if (rawLandmarks is Map<Object?, PoseLandmark>) {
+    return rawLandmarks.values;
+  }
+  return const <PoseLandmark>[];
+}
+
+double _clampUnit(num value) => value.clamp(0.0, 1.0).toDouble();
+
 /// 将 ML Kit 的 Pose → List<NeutralKeypoint>
 /// - 会做坐标归一化（x/width, y/height）
 /// - 可选筛除低置信度点
@@ -131,22 +144,26 @@ List<NeutralKeypoint> adaptMlKitPose({
   final int w = (width <= 0) ? 1 : width;
   final int h = (height <= 0) ? 1 : height;
 
+  final Map<PoseLandmarkType, PoseLandmark> landmarksByType = {
+    for (final landmark in _iterableLandmarks(pose)) landmark.type: landmark,
+  };
+
   for (final type in _mlkitLandmarkOrder) {
-    final landmark = pose.landmarks[type];
+    final landmark = landmarksByType[type];
     if (landmark == null) continue;
 
     final neutralName = _mlkitTypeToNeutralName[type];
     if (neutralName == null) continue;
 
-    final double s = (_extractLikelihood(landmark) ?? 1.0).clamp(0.0, 1.0);
+    final double s = _clampUnit(_extractLikelihood(landmark) ?? 1.0);
     if (s < minScore) {
       continue;
     }
 
     out.add(NeutralKeypoint(
       name: neutralName,
-      x: (landmark.x / w).clamp(0.0, 1.0),
-      y: (landmark.y / h).clamp(0.0, 1.0),
+      x: _clampUnit(landmark.x / w),
+      y: _clampUnit(landmark.y / h),
       z: keepZ ? landmark.z : null,
       score: s,
     ));
@@ -154,7 +171,7 @@ List<NeutralKeypoint> adaptMlKitPose({
 
   if (out.isEmpty && !returnEmptyWhenLow) {
     for (final type in _mlkitLandmarkOrder) {
-      final landmark = pose.landmarks[type];
+      final landmark = landmarksByType[type];
       if (landmark == null) continue;
 
       final neutralName = _mlkitTypeToNeutralName[type];
@@ -162,10 +179,10 @@ List<NeutralKeypoint> adaptMlKitPose({
 
       out.add(NeutralKeypoint(
         name: neutralName,
-        x: (landmark.x / w).clamp(0.0, 1.0),
-        y: (landmark.y / h).clamp(0.0, 1.0),
+        x: _clampUnit(landmark.x / w),
+        y: _clampUnit(landmark.y / h),
         z: keepZ ? landmark.z : null,
-        score: (_extractLikelihood(landmark) ?? 1.0).clamp(0.0, 1.0),
+        score: _clampUnit(_extractLikelihood(landmark) ?? 1.0),
       ));
     }
   }

--- a/aiwa_milestone_a/lib/pose/frame_streamer.dart
+++ b/aiwa_milestone_a/lib/pose/frame_streamer.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'pose_engine.dart';
+
+class RawImageFrame {
+  final Uint8List bytes;
+  final int width;
+  final int height;
+  final int rotationDeg;
+
+  const RawImageFrame({
+    required this.bytes,
+    required this.width,
+    required this.height,
+    this.rotationDeg = 0,
+  });
+}
+
+class FrameStreamerConfig {
+  final double fps;
+  final int stride;
+  final bool mirror;
+  final String engineName;
+  final String modelName;
+  final String sdkVersion;
+  final String videoBasename;
+
+  const FrameStreamerConfig({
+    required this.engineName,
+    required this.modelName,
+    required this.sdkVersion,
+    required this.videoBasename,
+    this.fps = 30.0,
+    this.stride = 2,
+    this.mirror = true,
+  })  : assert(fps > 0),
+        assert(stride > 0);
+
+  double get effectiveFps => fps / stride;
+}
+
+class FrameStreamResult {
+  final FrameStreamerConfig config;
+  final List<NeutralFrame> frames;
+  final int width;
+  final int height;
+  final double frameIntervalMs;
+  final int durationMs;
+
+  const FrameStreamResult({
+    required this.config,
+    required this.frames,
+    required this.width,
+    required this.height,
+    required this.frameIntervalMs,
+    required this.durationMs,
+  });
+
+  Map<String, dynamic> toNeutralKeypointsJson() => {
+        'version': 'vB1.1',
+        'video': {
+          'fpsIntended': config.fps,
+          'width': width,
+          'height': height,
+          'durationMs': durationMs,
+        },
+        'engine': {
+          'name': config.engineName,
+          'model': config.modelName,
+          'sdkVersion': config.sdkVersion,
+        },
+        'sampling': {
+          'stride': config.stride,
+          'effectiveFps': config.effectiveFps,
+        },
+        'frames': frames.map((f) => f.toJson()).toList(),
+      };
+}
+
+class FrameStreamer {
+  final PoseEngine _engine;
+  final PoseEngineConfig _engineConfig;
+  final FrameStreamerConfig _config;
+
+  FrameStreamer({
+    required PoseEngine engine,
+    required PoseEngineConfig engineConfig,
+    required FrameStreamerConfig config,
+  })  : _engine = engine,
+        _engineConfig = engineConfig,
+        _config = config;
+
+  Future<FrameStreamResult> run(Stream<RawImageFrame> frameStream) async {
+    await _engine.init(_engineConfig);
+
+    final outputs = <NeutralFrame>[];
+    int? firstWidth;
+    int? firstHeight;
+    var processedIndex = 0;
+    var sourceIndex = 0;
+    final frameIntervalMs = 1000.0 * _config.stride / _config.fps;
+    var timestampAccumulatorMs = 0.0;
+
+    try {
+      await for (final raw in frameStream) {
+        final currentSource = sourceIndex;
+        sourceIndex++;
+
+        firstWidth ??= raw.width;
+        firstHeight ??= raw.height;
+
+        if (currentSource % _config.stride != 0) {
+          continue;
+        }
+
+        final frameTimestampMs = timestampAccumulatorMs.round();
+        final frame = await _engine.infer(PoseEngineInput(
+          imageBytes: raw.bytes,
+          width: raw.width,
+          height: raw.height,
+          rotationDeg: raw.rotationDeg,
+          frameIndex: processedIndex,
+          timestampMs: frameTimestampMs,
+          mirrorHorizontally: _config.mirror,
+        ));
+
+        outputs.add(frame);
+        processedIndex++;
+        timestampAccumulatorMs += frameIntervalMs;
+      }
+    } finally {
+      await _engine.close();
+    }
+
+    final totalDurationMs = outputs.isEmpty ? 0 : timestampAccumulatorMs.round();
+
+    return FrameStreamResult(
+      config: _config,
+      frames: outputs,
+      width: firstWidth ?? 0,
+      height: firstHeight ?? 0,
+      frameIntervalMs: frameIntervalMs,
+      durationMs: totalDurationMs,
+    );
+  }
+}

--- a/aiwa_milestone_a/lib/pose/mlkit_pose_engine.dart
+++ b/aiwa_milestone_a/lib/pose/mlkit_pose_engine.dart
@@ -85,6 +85,8 @@ class MlKitPoseEngine implements PoseEngine {
         width: input.width,
         height: input.height,
         keypoints: const [],
+        lowConfidence: true,
+        mirrorApplied: input.mirrorHorizontally,
       );
     }
 
@@ -97,13 +99,31 @@ class MlKitPoseEngine implements PoseEngine {
       minScore: _config.minScore,
       returnEmptyWhenLow: _config.returnEmptyWhenLow,
     );
+    final processed = input.mirrorHorizontally
+        ? keypoints
+            .map((kp) =>
+                kp.copyWith(x: (1.0 - kp.x).clamp(0.0, 1.0).toDouble()))
+            .toList(growable: false)
+        : List<NeutralKeypoint>.from(keypoints, growable: false);
+
+    final filtered =
+        processed.where((kp) => kp.score >= 0.3).toList(growable: false);
+    final highConfidenceCount =
+        processed.where((kp) => kp.score >= 0.5).length;
+    final highConfidenceRatio = kMlKitNeutralKeypointCount == 0
+        ? 0.0
+        : highConfidenceCount / kMlKitNeutralKeypointCount;
+    final bool lowConfidence =
+        processed.isEmpty || highConfidenceRatio < 0.7;
 
     return NeutralFrame(
       frameIndex: input.frameIndex,
       timestampMs: input.timestampMs,
       width: input.width,
       height: input.height,
-      keypoints: keypoints,
+      keypoints: filtered,
+      lowConfidence: lowConfidence,
+      mirrorApplied: input.mirrorHorizontally,
     );
   }
 

--- a/aiwa_milestone_a/lib/pose/pose_engine.dart
+++ b/aiwa_milestone_a/lib/pose/pose_engine.dart
@@ -10,11 +10,11 @@ import 'dart:typed_data';
 
 /// 中立关键点：统一名称 + 归一化坐标 + 置信度 + 可选深度
 class NeutralKeypoint {
-  final String name;   // 例如 nose、leftHip、rightKnee 等
-  final double x;      // 归一化到 [0,1]，相对于帧宽
-  final double y;      // 归一化到 [0,1]，相对于帧高（注意坐标系：屏幕/图像坐标）
-  final double? z;     // 可选（ML Kit 提供实验性 Z）
-  final double score;  // 置信度 [0,1]
+  final String name; // 例如 nose、leftHip、rightKnee 等
+  final double x; // 归一化到 [0,1]，相对于帧宽
+  final double y; // 归一化到 [0,1]，相对于帧高（注意坐标系：屏幕/图像坐标）
+  final double? z; // 可选（ML Kit 提供实验性 Z）
+  final double score; // 置信度 [0,1]
 
   const NeutralKeypoint({
     required this.name,
@@ -23,6 +23,21 @@ class NeutralKeypoint {
     required this.score,
     this.z,
   });
+
+  NeutralKeypoint copyWith({
+    double? x,
+    double? y,
+    double? score,
+    double? z,
+  }) {
+    return NeutralKeypoint(
+      name: name,
+      x: x ?? this.x,
+      y: y ?? this.y,
+      score: score ?? this.score,
+      z: z ?? this.z,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
         'name': name,
@@ -35,11 +50,13 @@ class NeutralKeypoint {
 
 /// 单帧中立关键点及其时间/尺寸信息（便于导出与离线管线使用）
 class NeutralFrame {
-  final int frameIndex;      // 序号（从 0 递增）
-  final double timestampMs;  // 该帧时间戳（毫秒）
-  final int width;           // 原始帧宽（像素）
-  final int height;          // 原始帧高（像素）
+  final int frameIndex; // 序号（从 0 递增）
+  final int timestampMs; // 该帧时间戳（毫秒）
+  final int width; // 原始帧宽（像素）
+  final int height; // 原始帧高（像素）
   final List<NeutralKeypoint> keypoints;
+  final bool lowConfidence; // 当前帧是否低置信
+  final bool mirrorApplied; // 是否进行了镜像翻转
 
   const NeutralFrame({
     required this.frameIndex,
@@ -47,13 +64,15 @@ class NeutralFrame {
     required this.width,
     required this.height,
     required this.keypoints,
+    this.lowConfidence = false,
+    this.mirrorApplied = false,
   });
 
   Map<String, dynamic> toJson() => {
         'frameIndex': frameIndex,
         'timestampMs': timestampMs,
-        'width': width,
-        'height': height,
+        'lowConfidence': lowConfidence,
+        'mirrorApplied': mirrorApplied,
         'keypoints': keypoints.map((e) => e.toJson()).toList(),
       };
 }
@@ -82,7 +101,8 @@ class PoseEngineInput {
   final int height;
   final int rotationDeg; // 图像旋转角（如相机传感器方向）
   final int frameIndex;
-  final double timestampMs;
+  final int timestampMs;
+  final bool mirrorHorizontally;
 
   PoseEngineInput({
     required this.width,
@@ -91,6 +111,7 @@ class PoseEngineInput {
     required this.timestampMs,
     this.imageBytes,
     this.rotationDeg = 0,
+    this.mirrorHorizontally = false,
   });
 }
 

--- a/aiwa_milestone_a/lib/result/neutral_keypoints_export.dart
+++ b/aiwa_milestone_a/lib/result/neutral_keypoints_export.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import '../pose/frame_streamer.dart';
+
+Future<File> writeNeutralKeypointsJson({
+  required FrameStreamResult result,
+  required Directory outputRoot,
+  bool pretty = true,
+}) async {
+  final outDir = Directory(
+    p.join(outputRoot.path, result.config.videoBasename),
+  );
+  if (!outDir.existsSync()) {
+    outDir.createSync(recursive: true);
+  }
+
+  final file = File(p.join(outDir.path, 'neutral_keypoints.json'));
+  final encoder =
+      pretty ? const JsonEncoder.withIndent('  ') : const JsonEncoder();
+  final jsonStr = encoder.convert(result.toNeutralKeypointsJson());
+  await file.writeAsString(jsonStr);
+  return file;
+}


### PR DESCRIPTION
## Summary
- prevent the CLI ArgParser instance from shadowing the imported path helper and clean up the strictness handling when running the offline pipeline
- restore deterministic ML Kit landmark ordering while adding a safe likelihood extraction helper that falls back when the SDK omits confidences

## Testing
- not run (Dart SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68ec5c7316b083269a831ebfc400c903