### PR TITLE
Fix ML Kit keypoint adapter lookup

### DIFF
--- a/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
+++ b/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
@@ -131,8 +131,12 @@ List<NeutralKeypoint> adaptMlKitPose({
   final int w = (width <= 0) ? 1 : width;
   final int h = (height <= 0) ? 1 : height;
 
+  final Map<PoseLandmarkType, PoseLandmark> landmarksByType = {
+    for (final landmark in pose.landmarks) landmark.type: landmark,
+  };
+
   for (final type in _mlkitLandmarkOrder) {
-    final landmark = pose.landmarks[type];
+    final landmark = landmarksByType[type];
     if (landmark == null) continue;
 
     final neutralName = _mlkitTypeToNeutralName[type];
@@ -154,7 +158,7 @@ List<NeutralKeypoint> adaptMlKitPose({
 
   if (out.isEmpty && !returnEmptyWhenLow) {
     for (final type in _mlkitLandmarkOrder) {
-      final landmark = pose.landmarks[type];
+      final landmark = landmarksByType[type];
       if (landmark == null) continue;
 
       final neutralName = _mlkitTypeToNeutralName[type];


### PR DESCRIPTION
## Summary
- build a lookup map from ML Kit pose landmarks keyed by type
- use the map when adapting landmarks to neutral keypoints, including low-confidence fallbacks

## Testing
- Not run (Dart SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68edafac7a0483269f436ee2efda6fa7