### PR TITLE
Normalize ML Kit pose landmark access

### DIFF
--- a/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
+++ b/aiwa_milestone_a/lib/pose/adapter/keypoint_adapter.dart
@@ -99,7 +99,7 @@ const List<PoseLandmarkType> _mlkitLandmarkOrder = [
   PoseLandmarkType.rightFootIndex,
 ];
 
-const int kMlKitNeutralKeypointCount = _mlkitLandmarkOrder.length;
+const int kMlKitNeutralKeypointCount = 33;
 
 double? _extractLikelihood(PoseLandmark landmark) {
   final dynamic dynamicLandmark = landmark;
@@ -114,6 +114,30 @@ double? _extractLikelihood(PoseLandmark landmark) {
   }
   return null;
 }
+
+Map<PoseLandmarkType, PoseLandmark> _landmarksByType(Pose pose) {
+  final dynamic rawLandmarks = pose.landmarks;
+  if (rawLandmarks is Map<PoseLandmarkType, PoseLandmark>) {
+    return rawLandmarks;
+  }
+
+  if (rawLandmarks is Iterable<PoseLandmark>) {
+    return {
+      for (final landmark in rawLandmarks) landmark.type: landmark,
+    };
+  }
+
+  if (rawLandmarks is Iterable) {
+    return {
+      for (final item in rawLandmarks)
+        if (item is PoseLandmark) item.type: item,
+    };
+  }
+
+  return <PoseLandmarkType, PoseLandmark>{};
+}
+
+double _clampUnit(num value) => value.clamp(0.0, 1.0).toDouble();
 
 /// 将 ML Kit 的 Pose → List<NeutralKeypoint>
 /// - 会做坐标归一化（x/width, y/height）
@@ -131,22 +155,25 @@ List<NeutralKeypoint> adaptMlKitPose({
   final int w = (width <= 0) ? 1 : width;
   final int h = (height <= 0) ? 1 : height;
 
+  final Map<PoseLandmarkType, PoseLandmark> landmarksByType =
+      _landmarksByType(pose);
+
   for (final type in _mlkitLandmarkOrder) {
-    final landmark = pose.landmarks[type];
+    final landmark = landmarksByType[type];
     if (landmark == null) continue;
 
     final neutralName = _mlkitTypeToNeutralName[type];
     if (neutralName == null) continue;
 
-    final double s = (_extractLikelihood(landmark) ?? 1.0).clamp(0.0, 1.0);
+    final double s = _clampUnit(_extractLikelihood(landmark) ?? 1.0);
     if (s < minScore) {
       continue;
     }
 
     out.add(NeutralKeypoint(
       name: neutralName,
-      x: (landmark.x / w).clamp(0.0, 1.0),
-      y: (landmark.y / h).clamp(0.0, 1.0),
+      x: _clampUnit(landmark.x / w),
+      y: _clampUnit(landmark.y / h),
       z: keepZ ? landmark.z : null,
       score: s,
     ));
@@ -154,7 +181,7 @@ List<NeutralKeypoint> adaptMlKitPose({
 
   if (out.isEmpty && !returnEmptyWhenLow) {
     for (final type in _mlkitLandmarkOrder) {
-      final landmark = pose.landmarks[type];
+      final landmark = landmarksByType[type];
       if (landmark == null) continue;
 
       final neutralName = _mlkitTypeToNeutralName[type];
@@ -162,10 +189,10 @@ List<NeutralKeypoint> adaptMlKitPose({
 
       out.add(NeutralKeypoint(
         name: neutralName,
-        x: (landmark.x / w).clamp(0.0, 1.0),
-        y: (landmark.y / h).clamp(0.0, 1.0),
+        x: _clampUnit(landmark.x / w),
+        y: _clampUnit(landmark.y / h),
         z: keepZ ? landmark.z : null,
-        score: (_extractLikelihood(landmark) ?? 1.0).clamp(0.0, 1.0),
+        score: _clampUnit(_extractLikelihood(landmark) ?? 1.0),
       ));
     }
   }


### PR DESCRIPTION
## Summary
- resolve const evaluation errors by hard-coding the ML Kit landmark count used by neutral keypoint consumers
- normalize ML Kit pose landmarks to a map irrespective of whether the SDK yields a map or iterable collection

## Testing
- `dart analyze` *(fails: Dart SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68edafac7a0483269f436ee2efda6fa7