### PR TITLE
feat: add milestone examples runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,3 +75,91 @@
 - 修改或新增脚本时，请在对应包目录更新文档与依赖说明。
 - 提交前运行 `dart test`（核心）或相应 `flutter test`，确保新增逻辑的稳定性；若涉及代码生成，请执行 `dart run build_runner build --delete-conflicting-outputs` 并提交生成文件。
 - 确保 CLI 入参与输出路径在文档或 README 中更新，以便团队成员快速复现。
+
+## Milestone E 任务描述（Milestone C 测试与样例阶段）
+
+### 阶段目标
+
+- 证明功能可靠、性能达标、边界条件安全。
+- 通过生成并运行多种测试样本，验证整个系统在不同输入条件下能否稳定、准确、可复现地工作。
+
+### 总体要求
+
+1. **功能验证**：确认 C 阶段新增的 CLI 参数、Hybrid 触发、Schema 字段、证据化输出全通。
+2. **稳定性验证**：不同素材与设备下结果变化小，误差在容差范围内。
+3. **回归防护**：生成 Golden 样本 `expected/` 目录，用于后续版本自动比对。
+4. **性能监测**：自动输出 `perf.json` 并检查帧率、耗时、内存，防止性能退化。
+
+### 样本类别（共 5 类）
+
+| 类型      | 目录名                                            | 输入内容                           | 测试目的                        |
+| --------- | ------------------------------------------------- | ---------------------------------- | ------------------------------- |
+| ✅ 正常样本  | `examples/squat_normal/`                          | 光照正常、动作标准的视频或关键点文件             | 验证主流程与输出格式                  |
+| ⚠️ 异常样本 | `examples/squat_occlusion/`                       | 遮挡/低光素材 + `hybrid_policy.json` | 验证 Hybrid 触发与 cloud mock 合并 |
+| ⏱ 性能样本  | `examples/squat_short/`、`examples/squat_long/`   | 超短 (< 5 s) 与超长 (> 5 min) 视频  | 测试耗时、内存、降级逻辑                |
+| 🌀 节奏样本 | `examples/squat_tempo_irregular/`                 | 动作忽快忽慢、停顿素材                    | 检查节奏与评分稳健性                  |
+| 🧪 噪声样本 | `examples/squat_noisy_keypoints/`                 | 在关键点中注入抖动或置信度噪声                | 测系统鲁棒性（输出不乱跳）               |
+
+### 每个样本的文件结构
+
+```
+input.mp4 或 neutral_keypoints.json
+hybrid_policy.json        # 若涉及 Hybrid 触发
+cloud_result.json         # 若涉及云端 mock
+expected/
+  ├── result.json
+  ├── angles.csv
+  └── evidence.json
+  README.md               # 说明样本目的、触发条件、预期结果
+  perf.json               # 记录性能指标（timingsMs、RTF、内存等）
+```
+
+### 输出格式规范
+
+要求 AI Agent 生成统一结构的 JSON 描述（便于 CI 识别）：
+
+```json
+{
+  "sampleId": "squat_occlusion",
+  "category": "异常样本",
+  "purpose": "验证 Hybrid 触发与云端合并逻辑",
+  "inputs": ["input.mp4", "hybrid_policy.json", "cloud_result.json"],
+  "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+  "validationRules": [
+    "hybrid.triggered == true",
+    "mergeStrategy == 'prefer-cloud-count-then-reconcile'",
+    "overlay.durationDiff <= 1s"
+  ]
+}
+```
+
+> **提示：**
+>
+> - `expected/*.json` 可用伪数据填充，但字段结构必须符合 Schema vB1.1 + C-augment。
+> - 所有文件命名与 CLI 输出规范保持一致。
+> - 若能，生成 `perf.json` 样例，含 `timingsMs`、`inferenceFps`、`cpuUtilAvgPct` 等字段。
+
+### 验收标准
+
+- 覆盖 5 类样本（正常/异常/性能/节奏/噪声）。
+- 每类样本产物完整：`result.json`、`angles.csv`、`evidence[]`、`perf.json`。
+- 校验脚本 PASS 率 = 100%。
+- 性能指标 ≤ 阈值：`RTF ≤ 1.0`、`memPeakMB ≤ 600`。
+- Golden 回归连续 3 次稳定 PASS。
+
+### 附加指令（可选）
+
+- `--generate-mock` → 允许 Agent 创建伪 keypoints 数据。
+- `--verify-schema` → 在生成样本时自动跑 schema 校验。
+- `--export-json` → 导出所有样本描述为 `examples_manifest.json` 供 CI 调用。
+
+### 使用建议
+
+- 将本提示词放入 `AGENTS.md > Milestone E 任务描述`。
+- 在 CI 或本地命令中执行：
+
+  ```bash
+  aiwa_agent run milestoneE_test_generation
+  ```
+
+  Agent 会自动创建 `examples/` 目录、生成样本定义与预期输出模板。

--- a/examples/examples_manifest.json
+++ b/examples/examples_manifest.json
@@ -1,0 +1,74 @@
+[
+  {
+    "sampleId": "squat_normal",
+    "category": "正常样本",
+    "purpose": "验证主流程在标准光照视频下的输出结构与评分稳定性",
+    "inputs": ["input.mp4"],
+    "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+    "validationRules": [
+      "hybrid.triggered == false",
+      "scores.overall >= 90",
+      "quality.coverage >= 0.92"
+    ]
+  },
+  {
+    "sampleId": "squat_occlusion",
+    "category": "异常样本",
+    "purpose": "验证 Hybrid 触发与云端合并逻辑",
+    "inputs": ["input.mp4", "hybrid_policy.json", "cloud_result.json"],
+    "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+    "validationRules": [
+      "hybrid.triggered == true",
+      "hybrid.mergeStrategy == 'prefer-cloud-count-then-reconcile'",
+      "hybrid.delta.countFinal == cloud_result.repCount"
+    ]
+  },
+  {
+    "sampleId": "squat_short",
+    "category": "性能样本",
+    "purpose": "验证超短素材下的启动开销与结果完整性",
+    "inputs": ["input.mp4"],
+    "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+    "validationRules": [
+      "perf.rtf < 0.5",
+      "repCount <= 1",
+      "hybrid.triggered == false"
+    ]
+  },
+  {
+    "sampleId": "squat_long",
+    "category": "性能样本",
+    "purpose": "验证超长素材下的内存峰值与降级策略",
+    "inputs": ["input.mp4"],
+    "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+    "validationRules": [
+      "perf.memPeakMB <= 600",
+      "abs(perf.rtf - 1.0) <= 0.1",
+      "repCount >= 70"
+    ]
+  },
+  {
+    "sampleId": "squat_tempo_irregular",
+    "category": "节奏样本",
+    "purpose": "检查节奏异常下的评分稳健性",
+    "inputs": ["neutral_keypoints.json"],
+    "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+    "validationRules": [
+      "issues.any(code == 'TEMPO_VARIATION')",
+      "scores.tempo < scores.form",
+      "hybrid.triggered == false"
+    ]
+  },
+  {
+    "sampleId": "squat_noisy_keypoints",
+    "category": "噪声样本",
+    "purpose": "验证关键点噪声时的鲁棒性",
+    "inputs": ["neutral_keypoints.json"],
+    "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+    "validationRules": [
+      "quality.lowConfidence == true",
+      "issues.any(code == 'NOISY_LANDMARKS')",
+      "perf.memPeakMB < 450"
+    ]
+  }
+]

--- a/examples/squat_long/README.md
+++ b/examples/squat_long/README.md
@@ -1,0 +1,10 @@
+# Squat Long Sample
+
+- **类别**：性能样本（超长）
+- **目的**：验证长时素材下的内存峰值、降级策略与 perf 报告。
+- **输入**：7 分钟 1080p 视频 (`input.mp4`)，含 80 次深蹲。
+- **预期**：
+  - `perf.json` 中 `memPeakMB` 保持在 600 MB 以下。
+  - `rtf` 接近 1.0，展示性能上限。
+  - `issues` 可记录疲劳相关 cue，`evidence` 包含多段摘要帧。
+- **验证脚本**：`aiwa_agent run milestoneE_test_generation --verify-schema --export-json`。

--- a/examples/squat_long/expected/evidence.json
+++ b/examples/squat_long/expected/evidence.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "segment",
+    "timestampMs": 1180,
+    "frameIndex": 36,
+    "repIndex": 1,
+    "cues": ["rep:baseline"],
+    "angles": {
+      "kneeMain": 90.8,
+      "trunk": 29.4
+    },
+    "thresholds": {
+      "depthMin": 90
+    },
+    "scoreImpact": 0.8,
+    "snapshotPath": "evidence/rep1_baseline.png"
+  },
+  {
+    "type": "segment",
+    "timestampMs": 184860,
+    "frameIndex": 5546,
+    "repIndex": 40,
+    "cues": ["fatigue:forward-lean"],
+    "angles": {
+      "kneeMain": 95.1,
+      "trunk": 41.3
+    },
+    "thresholds": {
+      "trunkMax": 35
+    },
+    "scoreImpact": -5.4,
+    "snapshotPath": "evidence/fatigue_segment.png"
+  }
+]

--- a/examples/squat_long/expected/perf.json
+++ b/examples/squat_long/expected/perf.json
@@ -1,0 +1,16 @@
+{
+  "timingsMs": {
+    "total": 378420.0,
+    "startup": 235.0,
+    "inference": 331200.0,
+    "postProcess": 32100.0,
+    "downsample": 14700.0
+  },
+  "inferenceFps": 28.6,
+  "cpuUtilAvgPct": 68.5,
+  "cpuUtilPeakPct": 86.4,
+  "gpuUtilAvgPct": 0.0,
+  "rtf": 0.96,
+  "memPeakMB": 552,
+  "notes": "Long-run perf capture with ring-buffer frame eviction enabled."
+}

--- a/examples/squat_long/input.mp4
+++ b/examples/squat_long/input.mp4
@@ -1,0 +1,1 @@
+placeholder binary: 7-minute squat endurance session for stress testing.

--- a/examples/squat_noisy_keypoints/README.md
+++ b/examples/squat_noisy_keypoints/README.md
@@ -1,0 +1,10 @@
+# Squat Noisy Keypoints Sample
+
+- **类别**：噪声样本
+- **目的**：验证关键点抖动、低置信时，滤波与评分是否稳定。
+- **输入**：带噪关键点 (`neutral_keypoints.json`)，置信度随机衰减模拟跟踪失败。
+- **预期**：
+  - `quality.lowConfidence` 在局部帧上升，但整体覆盖率仍可接受。
+  - `issues` 包含 `NOISY_LANDMARKS`，`evidence` 指向低置信帧。
+  - `perf.json` 与正常样本接近。
+- **验证脚本**：`aiwa_agent run milestoneE_test_generation --generate-mock --verify-schema`。

--- a/examples/squat_noisy_keypoints/expected/evidence.json
+++ b/examples/squat_noisy_keypoints/expected/evidence.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "frame",
+    "timestampMs": 1040,
+    "frameIndex": 16,
+    "repIndex": 1,
+    "cues": ["confidence:drop"],
+    "angles": {
+      "kneeMain": null,
+      "trunk": null
+    },
+    "thresholds": {
+      "scoreMin": 0.3
+    },
+    "scoreImpact": -4.2,
+    "snapshotPath": "evidence/noise_low_confidence.png"
+  }
+]

--- a/examples/squat_noisy_keypoints/expected/perf.json
+++ b/examples/squat_noisy_keypoints/expected/perf.json
@@ -1,0 +1,15 @@
+{
+  "timingsMs": {
+    "total": 1765.2,
+    "startup": 208.0,
+    "inference": 1214.6,
+    "postProcess": 242.6
+  },
+  "inferenceFps": 27.1,
+  "cpuUtilAvgPct": 61.0,
+  "cpuUtilPeakPct": 76.5,
+  "gpuUtilAvgPct": 0.0,
+  "rtf": 0.83,
+  "memPeakMB": 398,
+  "notes": "Noise-injected keypoints processed via smoothing fallback."
+}

--- a/examples/squat_noisy_keypoints/neutral_keypoints.json
+++ b/examples/squat_noisy_keypoints/neutral_keypoints.json
@@ -1,0 +1,70 @@
+{
+  "version": "vB1.1",
+  "video": {
+    "fpsIntended": 30,
+    "width": 720,
+    "height": 1280,
+    "durationMs": 3200
+  },
+  "engine": {
+    "name": "mlkit",
+    "model": "blazepose-full",
+    "sdkVersion": "1.3.0"
+  },
+  "sampling": {
+    "stride": 2,
+    "effectiveFps": 15.0
+  },
+  "frames": [
+    {
+      "frameIndex": 0,
+      "timestampMs": 0,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftKnee", "x": 0.45, "y": 0.64, "z": -0.05, "score": 0.93},
+        {"name": "rightKnee", "x": 0.55, "y": 0.63, "z": -0.04, "score": 0.94}
+      ]
+    },
+    {
+      "frameIndex": 8,
+      "timestampMs": 520,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftKnee", "x": 0.43, "y": 0.78, "z": -0.12, "score": 0.58},
+        {"name": "rightKnee", "x": 0.57, "y": 0.79, "z": -0.11, "score": 0.62}
+      ]
+    },
+    {
+      "frameIndex": 16,
+      "timestampMs": 1040,
+      "lowConfidence": true,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftKnee", "x": 0.44, "y": 0.85, "z": -0.18, "score": 0.29},
+        {"name": "rightKnee", "x": 0.56, "y": 0.87, "z": -0.17, "score": 0.27}
+      ]
+    },
+    {
+      "frameIndex": 28,
+      "timestampMs": 1820,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftKnee", "x": 0.42, "y": 0.70, "z": -0.09, "score": 0.72},
+        {"name": "rightKnee", "x": 0.58, "y": 0.71, "z": -0.08, "score": 0.75}
+      ]
+    },
+    {
+      "frameIndex": 40,
+      "timestampMs": 2600,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftKnee", "x": 0.45, "y": 0.68, "z": -0.07, "score": 0.88},
+        {"name": "rightKnee", "x": 0.55, "y": 0.69, "z": -0.06, "score": 0.90}
+      ]
+    }
+  ]
+}

--- a/examples/squat_normal/README.md
+++ b/examples/squat_normal/README.md
@@ -1,0 +1,11 @@
+# Squat Normal Sample
+
+- **类别**：正常样本
+- **目的**：验证标准光照、标准姿势下的完整离线流程与输出格式。
+- **输入**：30 fps 日光环境视频 (`input.mp4`)，包含 10 次完整深蹲。
+- **预期**：
+  - CLI 生成 `expected/` 目录中的四个黄金产物（`result.json`、`angles.csv`、`evidence.json`、`perf.json`）。
+  - `hybrid.triggered` 为 `false`，代表未触发云端兜底。
+  - 评分应稳定在 90 分以上，节奏均衡。
+  - 质量覆盖率高于 0.92，低置信帧占比 < 5%。
+- **验证脚本**：使用 `aiwa_agent run milestoneE_test_generation --verify-schema` 对应项可以直接 PASS。

--- a/examples/squat_normal/expected/evidence.json
+++ b/examples/squat_normal/expected/evidence.json
@@ -1,0 +1,19 @@
+[
+  {
+    "type": "frame",
+    "timestampMs": 720,
+    "frameIndex": 12,
+    "repIndex": 1,
+    "cues": ["depth:good", "tempo:balanced"],
+    "angles": {
+      "kneeMain": 88.5,
+      "trunk": 28.2
+    },
+    "thresholds": {
+      "depthMin": 90,
+      "trunkMax": 35
+    },
+    "scoreImpact": 0.6,
+    "snapshotPath": "evidence/rep1_valley.png"
+  }
+]

--- a/examples/squat_normal/expected/perf.json
+++ b/examples/squat_normal/expected/perf.json
@@ -1,0 +1,15 @@
+{
+  "timingsMs": {
+    "total": 1840.5,
+    "loadModel": 112.3,
+    "inference": 1420.7,
+    "postProcess": 218.6
+  },
+  "inferenceFps": 28.4,
+  "cpuUtilAvgPct": 63.8,
+  "cpuUtilPeakPct": 79.5,
+  "gpuUtilAvgPct": 0.0,
+  "rtf": 0.82,
+  "memPeakMB": 412,
+  "notes": "Pixel 7 trace, offline pipeline default settings."
+}

--- a/examples/squat_normal/input.mp4
+++ b/examples/squat_normal/input.mp4
@@ -1,0 +1,1 @@
+placeholder binary: squat normal daylight clip captured at 30fps.

--- a/examples/squat_occlusion/README.md
+++ b/examples/squat_occlusion/README.md
@@ -1,0 +1,14 @@
+# Squat Occlusion Sample
+
+- **类别**：异常样本
+- **目的**：验证在低光与遮挡条件下 Hybrid 触发与云端合并逻辑是否正确。
+- **输入**：
+  - 遮挡视频 (`input.mp4`)
+  - 混合触发策略 (`hybrid_policy.json`)
+  - 云端推理 mock (`cloud_result.json`)
+- **预期**：
+  - 本地覆盖率低于阈值时触发 `hybrid.triggered == true`。
+  - `hybrid.mergeStrategy` 固定 `prefer-cloud-count-then-reconcile`。
+  - 最终 `repCount` 取云端计数并提供 `delta` 说明。
+  - `expected/perf.json` 记录性能退化与回传耗时。
+- **验证脚本**：`aiwa_agent run milestoneE_test_generation --verify-schema --generate-mock`。

--- a/examples/squat_occlusion/cloud_result.json
+++ b/examples/squat_occlusion/cloud_result.json
@@ -1,0 +1,22 @@
+{
+  "source": "cloud-mock",
+  "repCount": 11,
+  "scores": {
+    "form": 88.2,
+    "stability": 90.1,
+    "tempo": 92.0,
+    "overall": 89.7
+  },
+  "issues": [
+    {
+      "code": "DEPTH_INSUFFICIENT",
+      "frames": [1820],
+      "severity": "major"
+    }
+  ],
+  "metadata": {
+    "model": "pose-lite-cloud",
+    "version": "2024.05.mock",
+    "latencyMs": 950
+  }
+}

--- a/examples/squat_occlusion/expected/evidence.json
+++ b/examples/squat_occlusion/expected/evidence.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "frame",
+    "timestampMs": 480,
+    "frameIndex": 8,
+    "repIndex": 1,
+    "cues": ["quality:low-coverage"],
+    "angles": {
+      "kneeMain": 101.2,
+      "trunk": 34.8
+    },
+    "thresholds": {
+      "coverage": 0.7
+    },
+    "scoreImpact": -6.5,
+    "snapshotPath": "evidence/quality_drop.png"
+  },
+  {
+    "type": "frame",
+    "timestampMs": 840,
+    "frameIndex": 12,
+    "repIndex": 1,
+    "cues": ["valgus:inward-knee"],
+    "angles": {
+      "kneeOut": 3.8,
+      "trunk": 41.5
+    },
+    "thresholds": {
+      "valgusMin": 5
+    },
+    "scoreImpact": -8.4,
+    "snapshotPath": "evidence/valgus_peak.png"
+  }
+]

--- a/examples/squat_occlusion/expected/perf.json
+++ b/examples/squat_occlusion/expected/perf.json
@@ -1,0 +1,16 @@
+{
+  "timingsMs": {
+    "total": 2960.4,
+    "loadModel": 118.2,
+    "inference": 2150.7,
+    "postProcess": 340.5,
+    "cloudMerge": 351.0
+  },
+  "inferenceFps": 19.6,
+  "cpuUtilAvgPct": 71.4,
+  "cpuUtilPeakPct": 88.9,
+  "gpuUtilAvgPct": 0.0,
+  "rtf": 1.24,
+  "memPeakMB": 488,
+  "notes": "Occlusion handling triggered hybrid fallback; includes network mock latency."
+}

--- a/examples/squat_occlusion/hybrid_policy.json
+++ b/examples/squat_occlusion/hybrid_policy.json
@@ -1,0 +1,13 @@
+{
+  "policyVersion": "c-h1",
+  "trigger": {
+    "lowConfidenceThreshold": 0.7,
+    "minOcclusionFrames": 12,
+    "enableCloudFallback": true
+  },
+  "merge": {
+    "strategy": "prefer-cloud-count-then-reconcile",
+    "maxCountDelta": 2,
+    "allowScoreBlend": true
+  }
+}

--- a/examples/squat_occlusion/input.mp4
+++ b/examples/squat_occlusion/input.mp4
@@ -1,0 +1,1 @@
+placeholder binary: low-light squat session with intermittent occlusions.

--- a/examples/squat_short/README.md
+++ b/examples/squat_short/README.md
@@ -1,0 +1,10 @@
+# Squat Short Sample
+
+- **类别**：性能样本（超短）
+- **目的**：验证超短素材下的吞吐、启动时间与降级逻辑。
+- **输入**：约 3 秒视频 (`input.mp4`)，仅包含 2 次半 squat 动作。
+- **预期**：
+  - CLI 正确生成空/部分 rep 的结果并填充性能统计。
+  - `rtf` 需明显低于 1，展示超短素材的实时能力。
+  - `issues` 允许为空，但 `perf.json.timingsMs.startup` 应记录冷启动成本。
+- **验证脚本**：`aiwa_agent run milestoneE_test_generation --export-json`。

--- a/examples/squat_short/expected/evidence.json
+++ b/examples/squat_short/expected/evidence.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "frame",
+    "timestampMs": 260,
+    "frameIndex": 5,
+    "repIndex": 1,
+    "cues": ["rep:completed"],
+    "angles": {
+      "kneeMain": 92.1,
+      "trunk": 22.4
+    },
+    "thresholds": {
+      "depthMin": 90
+    },
+    "scoreImpact": 0.0,
+    "snapshotPath": "evidence/rep1_valley.png"
+  }
+]

--- a/examples/squat_short/expected/perf.json
+++ b/examples/squat_short/expected/perf.json
@@ -1,0 +1,15 @@
+{
+  "timingsMs": {
+    "total": 620.5,
+    "startup": 240.0,
+    "inference": 260.3,
+    "postProcess": 90.2
+  },
+  "inferenceFps": 32.5,
+  "cpuUtilAvgPct": 57.6,
+  "cpuUtilPeakPct": 74.3,
+  "gpuUtilAvgPct": 0.0,
+  "rtf": 0.32,
+  "memPeakMB": 298,
+  "notes": "Short clip benchmark highlighting startup overhead dominance."
+}

--- a/examples/squat_short/input.mp4
+++ b/examples/squat_short/input.mp4
@@ -1,0 +1,1 @@
+placeholder binary: 3-second squat drill clip for latency benchmarking.

--- a/examples/squat_tempo_irregular/README.md
+++ b/examples/squat_tempo_irregular/README.md
@@ -1,0 +1,10 @@
+# Squat Tempo Irregular Sample
+
+- **类别**：节奏样本
+- **目的**：验证快慢节奏交替与停顿时，评分与节奏统计是否稳定。
+- **输入**：关键点时间序列 (`neutral_keypoints.json`)，人工注入长停顿与急速下蹲。
+- **预期**：
+  - `tempo` 分数下降但整体计数不受影响。
+  - `evidence` 列出节奏异常帧，`issues` 包含 `TEMPO_VARIATION` 提示。
+  - `perf.json` 近似正常样本，因为样本帧数有限。
+- **验证脚本**：`aiwa_agent run milestoneE_test_generation --verify-schema --generate-mock`。

--- a/examples/squat_tempo_irregular/expected/evidence.json
+++ b/examples/squat_tempo_irregular/expected/evidence.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "frame",
+    "timestampMs": 1240,
+    "frameIndex": 21,
+    "repIndex": 2,
+    "cues": ["tempo:slow-up-phase"],
+    "angles": {
+      "kneeMain": 85.7,
+      "trunk": 32.4
+    },
+    "thresholds": {
+      "tempoRatioMax": 1.3
+    },
+    "scoreImpact": -7.6,
+    "snapshotPath": "evidence/tempo_variation.png"
+  }
+]

--- a/examples/squat_tempo_irregular/expected/perf.json
+++ b/examples/squat_tempo_irregular/expected/perf.json
@@ -1,0 +1,15 @@
+{
+  "timingsMs": {
+    "total": 1820.3,
+    "startup": 210.0,
+    "inference": 1290.5,
+    "postProcess": 219.8
+  },
+  "inferenceFps": 27.9,
+  "cpuUtilAvgPct": 62.1,
+  "cpuUtilPeakPct": 77.0,
+  "gpuUtilAvgPct": 0.0,
+  "rtf": 0.87,
+  "memPeakMB": 405,
+  "notes": "Synthetic tempo stress test derived from neutral keypoints."
+}

--- a/examples/squat_tempo_irregular/neutral_keypoints.json
+++ b/examples/squat_tempo_irregular/neutral_keypoints.json
@@ -1,0 +1,60 @@
+{
+  "version": "vB1.1",
+  "video": {
+    "fpsIntended": 30,
+    "width": 720,
+    "height": 1280,
+    "durationMs": 4200
+  },
+  "engine": {
+    "name": "mlkit",
+    "model": "blazepose-full",
+    "sdkVersion": "1.3.0"
+  },
+  "sampling": {
+    "stride": 2,
+    "effectiveFps": 15.0
+  },
+  "frames": [
+    {
+      "frameIndex": 0,
+      "timestampMs": 0,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftHip", "x": 0.48, "y": 0.72, "z": -0.12, "score": 0.92},
+        {"name": "rightHip", "x": 0.52, "y": 0.72, "z": -0.10, "score": 0.94}
+      ]
+    },
+    {
+      "frameIndex": 6,
+      "timestampMs": 400,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftHip", "x": 0.47, "y": 0.80, "z": -0.16, "score": 0.91},
+        {"name": "rightHip", "x": 0.53, "y": 0.83, "z": -0.18, "score": 0.90}
+      ]
+    },
+    {
+      "frameIndex": 18,
+      "timestampMs": 1200,
+      "lowConfidence": true,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftHip", "x": 0.48, "y": 0.86, "z": -0.20, "score": 0.42},
+        {"name": "rightHip", "x": 0.52, "y": 0.89, "z": -0.22, "score": 0.40}
+      ]
+    },
+    {
+      "frameIndex": 44,
+      "timestampMs": 2800,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftHip", "x": 0.49, "y": 0.74, "z": -0.11, "score": 0.95},
+        {"name": "rightHip", "x": 0.51, "y": 0.74, "z": -0.11, "score": 0.96}
+      ]
+    }
+  ]
+}

--- a/tools/examples_runner.dart
+++ b/tools/examples_runner.dart
@@ -1,0 +1,949 @@
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> main(List<String> args) async {
+  final options = RunnerOptions.parse(args);
+  final runner = ExamplesRunner(options);
+  final results = await runner.run();
+  final failed = results.where((r) => !r.passed).toList();
+  if (failed.isNotEmpty) {
+    exit(1);
+  }
+}
+
+class RunnerOptions {
+  RunnerOptions({
+    required this.manifestPath,
+    required this.rulePath,
+    required this.cliWorkingDir,
+    required this.cliEntry,
+    required this.outputRoot,
+    required this.dartExecutable,
+    required this.evidenceConfigPath,
+    required this.cueMapPath,
+    required this.verbose,
+    required this.onlySampleIds,
+  });
+
+  final String manifestPath;
+  final String rulePath;
+  final String cliWorkingDir;
+  final String cliEntry;
+  final String outputRoot;
+  final String dartExecutable;
+  final String evidenceConfigPath;
+  final String cueMapPath;
+  final bool verbose;
+  final List<String> onlySampleIds;
+
+  static void _printUsage() {
+    stdout.writeln('''examples_runner.dart — run AIWA CLI against Milestone C samples
+
+'
+        'Usage: dart tools/examples_runner.dart [options]
+
+'
+        'Options:
+'
+        '  --manifest <path>    Path to examples manifest JSON.
+'
+        '  --rule <path>        Path to squat rule JSON file.
+'
+        '  --out <path>         Output root directory for generated artifacts.
+'
+        '  --cli-dir <path>     Working directory containing aiwa_cli pubspec.
+'
+        '  --cli-entry <path>   CLI entrypoint relative to --cli-dir.
+'
+        '  --dart <path>        Dart executable to use (default: dart).
+'
+        '  --only <ids>         Comma-separated sample IDs to run.
+'
+        '  --verbose            Stream CLI output while running.
+'
+        '  --evidence-config    Override evidence config path.
+'
+        '  --cue-map            Override cue map path.
+'
+        '  -h, --help           Show this help message.
+''');
+  }
+
+  factory RunnerOptions.parse(List<String> args) {
+    var manifestPath = 'examples/examples_manifest.json';
+    var rulePath = 'aiwa_core/test/fixtures/squat.v1.json';
+    var outputRoot = 'build/examples_runner';
+    var cliDir = 'aiwa_cli';
+    var cliEntry = 'bin/aiwa_cli.dart';
+    var dartExecutable = 'dart';
+    var verbose = false;
+    final only = <String>[];
+    var evidenceConfigPath = 'configs/evidence_config.json';
+    var cueMapPath = 'rules/cue_advice_map.json';
+
+    for (var i = 0; i < args.length; i++) {
+      final arg = args[i];
+      if (arg == '--help' || arg == '-h') {
+        _printUsage();
+        exit(0);
+      } else if (arg.startsWith('--manifest=')) {
+        manifestPath = arg.substring('--manifest='.length);
+      } else if (arg == '--manifest') {
+        if (i + 1 >= args.length) {
+          _error('--manifest requires a value.');
+        }
+        manifestPath = args[++i];
+      } else if (arg.startsWith('--rule=')) {
+        rulePath = arg.substring('--rule='.length);
+      } else if (arg == '--rule') {
+        if (i + 1 >= args.length) {
+          _error('--rule requires a value.');
+        }
+        rulePath = args[++i];
+      } else if (arg.startsWith('--out=')) {
+        outputRoot = arg.substring('--out='.length);
+      } else if (arg == '--out') {
+        if (i + 1 >= args.length) {
+          _error('--out requires a value.');
+        }
+        outputRoot = args[++i];
+      } else if (arg.startsWith('--cli-dir=')) {
+        cliDir = arg.substring('--cli-dir='.length);
+      } else if (arg == '--cli-dir') {
+        if (i + 1 >= args.length) {
+          _error('--cli-dir requires a value.');
+        }
+        cliDir = args[++i];
+      } else if (arg.startsWith('--cli-entry=')) {
+        cliEntry = arg.substring('--cli-entry='.length);
+      } else if (arg == '--cli-entry') {
+        if (i + 1 >= args.length) {
+          _error('--cli-entry requires a value.');
+        }
+        cliEntry = args[++i];
+      } else if (arg.startsWith('--dart=')) {
+        dartExecutable = arg.substring('--dart='.length);
+      } else if (arg == '--dart') {
+        if (i + 1 >= args.length) {
+          _error('--dart requires a value.');
+        }
+        dartExecutable = args[++i];
+      } else if (arg == '--verbose') {
+        verbose = true;
+      } else if (arg.startsWith('--only=')) {
+        only.addAll(arg.substring('--only='.length)
+            .split(',')
+            .where((e) => e.trim().isNotEmpty)
+            .map((e) => e.trim()));
+      } else if (arg == '--only') {
+        if (i + 1 >= args.length) {
+          _error('--only requires a value.');
+        }
+        only.addAll(args[++i]
+            .split(',')
+            .where((e) => e.trim().isNotEmpty)
+            .map((e) => e.trim()));
+      } else if (arg.startsWith('--evidence-config=')) {
+        evidenceConfigPath = arg.substring('--evidence-config='.length);
+      } else if (arg == '--evidence-config') {
+        if (i + 1 >= args.length) {
+          _error('--evidence-config requires a value.');
+        }
+        evidenceConfigPath = args[++i];
+      } else if (arg.startsWith('--cue-map=')) {
+        cueMapPath = arg.substring('--cue-map='.length);
+      } else if (arg == '--cue-map') {
+        if (i + 1 >= args.length) {
+          _error('--cue-map requires a value.');
+        }
+        cueMapPath = args[++i];
+      } else {
+        _error('Unknown option: $arg');
+      }
+    }
+
+    return RunnerOptions(
+      manifestPath: _absoluteFilePath(manifestPath),
+      rulePath: _absoluteFilePath(rulePath),
+      cliWorkingDir: _absoluteDirPath(cliDir),
+      cliEntry: cliEntry,
+      outputRoot: _absoluteDirPath(outputRoot),
+      dartExecutable: dartExecutable,
+      evidenceConfigPath: _absoluteFilePath(evidenceConfigPath),
+      cueMapPath: _absoluteFilePath(cueMapPath),
+      verbose: verbose,
+      onlySampleIds: only,
+    );
+  }
+
+  static Never _error(String message) {
+    stderr.writeln('Error: $message');
+    _printUsage();
+    exit(64);
+  }
+}
+
+class ExamplesRunner {
+  ExamplesRunner(this.options);
+
+  final RunnerOptions options;
+
+  Future<List<SampleRunResult>> run() async {
+    final manifestFile = File(options.manifestPath);
+    if (!manifestFile.existsSync()) {
+      throw StateError('Manifest not found at ${options.manifestPath}');
+    }
+
+    final manifestRaw = jsonDecode(await manifestFile.readAsString());
+    if (manifestRaw is! List) {
+      throw StateError('Manifest root must be a JSON array.');
+    }
+
+    final specs = manifestRaw
+        .whereType<Map<String, dynamic>>()
+        .map(SampleSpec.fromJson)
+        .toList(growable: false);
+
+    final selectedSpecs = options.onlySampleIds.isEmpty
+        ? specs
+        : specs
+            .where((spec) => options.onlySampleIds.contains(spec.sampleId))
+            .toList(growable: false);
+
+    final missingRequested = options.onlySampleIds
+        .where((id) => !selectedSpecs.any((spec) => spec.sampleId == id))
+        .toList(growable: false);
+    if (missingRequested.isNotEmpty) {
+      stderr.writeln('Warning: requested sample(s) not found in manifest: '
+          '${missingRequested.join(', ')}');
+    }
+
+    final results = <SampleRunResult>[];
+    for (final spec in selectedSpecs) {
+      results.add(await _runSample(spec));
+    }
+
+    final passedCount = results.where((r) => r.passed).length;
+    final failed = results.where((r) => !r.passed).toList(growable: false);
+
+    stdout.writeln(
+        'Completed ${results.length} sample(s): $passedCount passed, ${failed.length} failed.');
+    if (failed.isNotEmpty) {
+      for (final result in failed) {
+        stderr.writeln('--- ${result.sampleId} FAILED ---');
+        for (final message in result.messages) {
+          stderr.writeln('  • $message');
+        }
+        if (result.stderrLines.isNotEmpty) {
+          stderr.writeln('  stderr:');
+          for (final line in result.stderrLines) {
+            stderr.writeln('    $line');
+          }
+        }
+        if (result.stdoutLines.isNotEmpty) {
+          stderr.writeln('  stdout:');
+          for (final line in result.stdoutLines) {
+            stderr.writeln('    $line');
+          }
+        }
+      }
+    }
+
+    return results;
+  }
+
+  Future<SampleRunResult> _runSample(SampleSpec spec) async {
+    stdout.writeln('[${spec.sampleId}] Running sample (${spec.category})...');
+    final sampleDir = Directory(
+      _resolvePath(Directory.current.path, 'examples/${spec.sampleId}'),
+    );
+    if (!sampleDir.existsSync()) {
+      return SampleRunResult.failure(
+        sampleId: spec.sampleId,
+        reason: 'Sample directory not found: ${sampleDir.path}',
+      );
+    }
+
+    String? keypointsPath;
+    String? videoPath;
+    String? hybridPolicyPath;
+    String? cloudMockPath;
+    Map<String, dynamic>? cloudResultData;
+
+    for (final input in spec.inputs) {
+      final resolved = _resolvePath(sampleDir.path, input);
+      final file = File(resolved);
+      if (!file.existsSync()) {
+        return SampleRunResult.failure(
+          sampleId: spec.sampleId,
+          reason: 'Missing input "$input" at $resolved',
+        );
+      }
+      if (input.endsWith('.json') && input.contains('keypoints')) {
+        keypointsPath = file.path;
+      } else if (input.endsWith('.mp4')) {
+        videoPath = file.path;
+      }
+      if (input == 'hybrid_policy.json') {
+        hybridPolicyPath = file.path;
+      } else if (input == 'cloud_result.json') {
+        cloudMockPath = file.path;
+        try {
+          final decoded = jsonDecode(file.readAsStringSync());
+          if (decoded is Map<String, dynamic>) {
+            cloudResultData = decoded;
+          } else {
+            return SampleRunResult.failure(
+              sampleId: spec.sampleId,
+              reason: 'cloud_result.json must decode to an object.',
+            );
+          }
+        } catch (e) {
+          return SampleRunResult.failure(
+            sampleId: spec.sampleId,
+            reason: 'Failed to parse cloud_result.json: $e',
+          );
+        }
+      }
+    }
+
+    if (keypointsPath == null) {
+      final reason = videoPath != null
+          ? 'Sample provides video input "$videoPath" but neutral_keypoints.json is required for CLI file mode.'
+          : 'Sample must include neutral_keypoints.json in inputs.';
+      return SampleRunResult.failure(sampleId: spec.sampleId, reason: reason);
+    }
+
+    final sampleOutRoot = Directory(_resolvePath(options.outputRoot, spec.sampleId));
+    if (sampleOutRoot.existsSync()) {
+      sampleOutRoot.deleteSync(recursive: true);
+    }
+    sampleOutRoot.createSync(recursive: true);
+
+    final cliArgs = <String>[
+      'run',
+      options.cliEntry,
+      '--keypoints',
+      keypointsPath!,
+      '--rule',
+      options.rulePath,
+      '--out',
+      sampleOutRoot.path,
+      '--strictness',
+      'relaxed',
+      '--evidence',
+      '--evidence-config',
+      options.evidenceConfigPath,
+      '--cue-map',
+      options.cueMapPath,
+      '--assert',
+      '--assert-level',
+      'strict',
+      '--assert-print',
+    ];
+
+    if (hybridPolicyPath != null || cloudMockPath != null) {
+      cliArgs.add('--hybrid');
+      if (hybridPolicyPath != null) {
+        cliArgs.addAll(['--hybrid-policy', hybridPolicyPath!]);
+      }
+      if (cloudMockPath != null) {
+        cliArgs.addAll(['--cloud-mock', cloudMockPath!]);
+      }
+    }
+
+    final process = await Process.start(
+      options.dartExecutable,
+      ['--disable-dart-dev', ...cliArgs],
+      workingDirectory: options.cliWorkingDir,
+    );
+
+    final stdoutFuture = process.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .map((line) {
+      if (options.verbose) {
+        stdout.writeln(line);
+      }
+      return line;
+    }).toList();
+
+    final stderrFuture = process.stderr
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .map((line) {
+      if (options.verbose) {
+        stderr.writeln(line);
+      }
+      return line;
+    }).toList();
+
+    final exitCode = await process.exitCode;
+    final cliStdout = await stdoutFuture;
+    final cliStderr = await stderrFuture;
+
+    if (exitCode != 0) {
+      return SampleRunResult.failure(
+        sampleId: spec.sampleId,
+        reason: 'CLI exited with code $exitCode',
+        stdoutLines: cliStdout,
+        stderrLines: cliStderr,
+      );
+    }
+
+    final keypointsBase = _basenameWithoutExtension(keypointsPath!);
+    final outDir = Directory(_resolvePath(sampleOutRoot.path, keypointsBase));
+    if (!outDir.existsSync()) {
+      return SampleRunResult.failure(
+        sampleId: spec.sampleId,
+        reason: 'Output directory not found: ${outDir.path}',
+        stdoutLines: cliStdout,
+        stderrLines: cliStderr,
+      );
+    }
+
+    final producedFiles = <String, File>{};
+    final missingOutputs = <String>[];
+    for (final expected in spec.expectedOutputs) {
+      final file = _locateOutputFile(outDir, expected);
+      if (file == null) {
+        missingOutputs.add(expected);
+      } else {
+        producedFiles[expected] = file;
+      }
+    }
+
+    if (missingOutputs.isNotEmpty) {
+      return SampleRunResult.failure(
+        sampleId: spec.sampleId,
+        reason: 'Missing expected outputs: ${missingOutputs.join(', ')}',
+        stdoutLines: cliStdout,
+        stderrLines: cliStderr,
+      );
+    }
+
+    final resultFile = producedFiles['result.json'];
+    final perfFile = producedFiles['perf.json'];
+
+    Map<String, dynamic> resultJson;
+    try {
+      resultJson = jsonDecode(await resultFile!.readAsString()) as Map<String, dynamic>;
+    } catch (e) {
+      return SampleRunResult.failure(
+        sampleId: spec.sampleId,
+        reason: 'Failed to parse result.json: $e',
+        stdoutLines: cliStdout,
+        stderrLines: cliStderr,
+      );
+    }
+
+    Map<String, dynamic>? perfJson;
+    if (perfFile != null) {
+      try {
+        final decoded = jsonDecode(await perfFile.readAsString());
+        if (decoded is Map<String, dynamic>) {
+          perfJson = decoded;
+        } else {
+          return SampleRunResult.failure(
+            sampleId: spec.sampleId,
+            reason: 'perf.json must be an object.',
+            stdoutLines: cliStdout,
+            stderrLines: cliStderr,
+          );
+        }
+      } catch (e) {
+        return SampleRunResult.failure(
+          sampleId: spec.sampleId,
+          reason: 'Failed to parse perf.json: $e',
+          stdoutLines: cliStdout,
+          stderrLines: cliStderr,
+        );
+      }
+    }
+
+    final repCount = _resolveRepCount(resultJson);
+    final ruleContext = RuleContext(
+      sampleId: spec.sampleId,
+      resultJson: resultJson,
+      perfJson: perfJson,
+      cloudResult: cloudResultData,
+      repCount: repCount,
+    );
+
+    final ruleFailures = <String>[];
+    for (final rule in spec.validationRules) {
+      final evaluation = evaluateRule(rule, ruleContext);
+      if (!evaluation.passed) {
+        final detail = evaluation.details == null
+            ? 'Rule "$rule" failed.'
+            : 'Rule "$rule" failed: ${evaluation.details}';
+        ruleFailures.add(detail);
+      }
+    }
+
+    if (ruleFailures.isNotEmpty) {
+      return SampleRunResult.failure(
+        sampleId: spec.sampleId,
+        reason: ruleFailures.join('; '),
+        stdoutLines: cliStdout,
+        stderrLines: cliStderr,
+      );
+    }
+
+    stdout.writeln('[${spec.sampleId}] ✅ Passed (${spec.validationRules.length} rule(s)).');
+    return SampleRunResult.success(
+      sampleId: spec.sampleId,
+      stdoutLines: cliStdout,
+      stderrLines: cliStderr,
+    );
+  }
+}
+
+class SampleSpec {
+  SampleSpec({
+    required this.sampleId,
+    required this.category,
+    required this.inputs,
+    required this.expectedOutputs,
+    required this.validationRules,
+  });
+
+  final String sampleId;
+  final String category;
+  final List<String> inputs;
+  final List<String> expectedOutputs;
+  final List<String> validationRules;
+
+  factory SampleSpec.fromJson(Map<String, dynamic> json) {
+    final sampleId = json['sampleId'] as String?;
+    if (sampleId == null || sampleId.isEmpty) {
+      throw StateError('Manifest entry missing sampleId.');
+    }
+
+    List<String> _stringList(dynamic value) {
+      if (value is List) {
+        return value.whereType<String>().toList(growable: false);
+      }
+      return const <String>[];
+    }
+
+    return SampleSpec(
+      sampleId: sampleId,
+      category: json['category'] as String? ?? 'unknown',
+      inputs: _stringList(json['inputs']),
+      expectedOutputs: _stringList(json['expectedOutputs']),
+      validationRules: _stringList(json['validationRules']),
+    );
+  }
+}
+
+class SampleRunResult {
+  SampleRunResult._({
+    required this.sampleId,
+    required this.passed,
+    required this.messages,
+    required this.stdoutLines,
+    required this.stderrLines,
+  });
+
+  factory SampleRunResult.success({
+    required String sampleId,
+    List<String>? stdoutLines,
+    List<String>? stderrLines,
+  }) {
+    return SampleRunResult._(
+      sampleId: sampleId,
+      passed: true,
+      messages: const [],
+      stdoutLines: stdoutLines ?? const [],
+      stderrLines: stderrLines ?? const [],
+    );
+  }
+
+  factory SampleRunResult.failure({
+    required String sampleId,
+    required String reason,
+    List<String>? stdoutLines,
+    List<String>? stderrLines,
+  }) {
+    return SampleRunResult._(
+      sampleId: sampleId,
+      passed: false,
+      messages: [reason],
+      stdoutLines: stdoutLines ?? const [],
+      stderrLines: stderrLines ?? const [],
+    );
+  }
+
+  final String sampleId;
+  final bool passed;
+  final List<String> messages;
+  final List<String> stdoutLines;
+  final List<String> stderrLines;
+}
+
+class RuleContext {
+  RuleContext({
+    required this.sampleId,
+    required this.resultJson,
+    required this.perfJson,
+    required this.cloudResult,
+    required this.repCount,
+  });
+
+  final String sampleId;
+  final Map<String, dynamic> resultJson;
+  final Map<String, dynamic>? perfJson;
+  final Map<String, dynamic>? cloudResult;
+  final int repCount;
+
+  Map<String, dynamic>? get hybrid => resultJson['hybrid'] as Map<String, dynamic>?;
+
+  Map<String, dynamic>? get scores => resultJson['scores'] as Map<String, dynamic>?;
+
+  Map<String, dynamic>? get quality => resultJson['quality'] as Map<String, dynamic>?;
+
+  List<Map<String, dynamic>> get issues =>
+      (resultJson['issues'] as List<dynamic>? ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .toList(growable: false);
+
+  double? get perfRtf {
+    final perf = perfJson?['perf'];
+    if (perf is Map<String, dynamic>) {
+      return _asDouble(perf['pipelineRtf']);
+    }
+    return _asDouble(perfJson?['rtf']);
+  }
+
+  double? get perfMemPeakMb {
+    final perf = perfJson?['perf'];
+    if (perf is Map<String, dynamic>) {
+      return _asDouble(perf['memPeakMB']);
+    }
+    return _asDouble(perfJson?['memPeakMB']);
+  }
+
+  double? get perfInferenceFps {
+    final perf = perfJson?['perf'];
+    if (perf is Map<String, dynamic>) {
+      return _asDouble(perf['inferenceFps']);
+    }
+    return _asDouble(perfJson?['inferenceFps']);
+  }
+}
+
+class RuleEvaluation {
+  const RuleEvaluation(this.passed, this.details);
+
+  final bool passed;
+  final String? details;
+}
+
+RuleEvaluation evaluateRule(String rule, RuleContext ctx) {
+  final trimmed = rule.trim();
+  if (trimmed.startsWith('issues.any(') && trimmed.endsWith(')')) {
+    return _evaluateIssuesAny(trimmed, ctx);
+  }
+  if (trimmed.startsWith('abs(')) {
+    return _evaluateAbsRule(trimmed, ctx);
+  }
+
+  final match = _comparisonRegex.firstMatch(trimmed);
+  if (match == null) {
+    return RuleEvaluation(false, 'Unsupported rule syntax.');
+  }
+
+  final leftExpr = match.group(1)!;
+  final operator = match.group(2)!;
+  final rightExpr = match.group(3)!;
+
+  final leftValue = _resolveValue(leftExpr, ctx);
+  final rightValue = _resolveValue(rightExpr, ctx);
+
+  final passed = _compareValues(leftValue, rightValue, operator);
+  if (passed) {
+    return const RuleEvaluation(true, null);
+  }
+  return RuleEvaluation(
+    false,
+    'Observed ${_formatValue(leftValue)} $operator ${_formatValue(rightValue)}',
+  );
+}
+
+RuleEvaluation _evaluateIssuesAny(String rule, RuleContext ctx) {
+  final inner = rule.substring('issues.any('.length, rule.length - 1);
+  final match = _comparisonRegex.firstMatch(inner.trim());
+  if (match == null) {
+    return RuleEvaluation(false, 'Invalid issues.any condition.');
+  }
+  final fieldExpr = match.group(1)!;
+  final operator = match.group(2)!;
+  final targetExpr = match.group(3)!;
+  final targetValue = _resolveValue(targetExpr, ctx);
+
+  if (operator != '==' && operator != '!=') {
+    return RuleEvaluation(false, 'issues.any supports == or != only.');
+  }
+
+  final fieldPath = fieldExpr.split('.');
+  bool matched = false;
+  for (final issue in ctx.issues) {
+    dynamic current = issue;
+    dynamic value;
+    for (final segment in fieldPath) {
+      if (current is Map<String, dynamic>) {
+        value = current[segment];
+        current = value is Map<String, dynamic> ? value : null;
+      } else {
+        value = null;
+        break;
+      }
+    }
+    if (_compareValues(value, targetValue, operator)) {
+      matched = true;
+      break;
+    }
+  }
+
+  if (matched) {
+    return const RuleEvaluation(true, null);
+  }
+
+  final availableCodes = ctx.issues.map((e) => e['code']).whereType<String>().toSet().join(', ');
+  final detail = availableCodes.isEmpty
+      ? 'No issues found.'
+      : 'Available issue codes: $availableCodes';
+  return RuleEvaluation(false, detail);
+}
+
+RuleEvaluation _evaluateAbsRule(String rule, RuleContext ctx) {
+  final closeIdx = rule.indexOf(')');
+  if (closeIdx == -1) {
+    return RuleEvaluation(false, 'Malformed abs() expression.');
+  }
+  final innerExpr = rule.substring(4, closeIdx);
+  final remainder = rule.substring(closeIdx + 1).trim();
+  final comparison = _comparisonRegex.firstMatch(remainder);
+  if (comparison == null) {
+    return RuleEvaluation(false, 'abs() must be followed by a comparison.');
+  }
+  final operator = comparison.group(2)!;
+  final rightExpr = comparison.group(3)!;
+  final numeric = _resolveNumericExpression(innerExpr, ctx);
+  final rightValueRaw = _resolveValue(rightExpr, ctx);
+  final rightValue = rightValueRaw is num ? rightValueRaw.toDouble() : _asDouble(rightValueRaw);
+  if (numeric == null || rightValue == null) {
+    return RuleEvaluation(false, 'abs() comparison requires numeric operands.');
+  }
+  final observed = numeric.abs();
+  final passed = _compareNumeric(observed, rightValue, operator);
+  if (passed) {
+    return const RuleEvaluation(true, null);
+  }
+  return RuleEvaluation(
+    false,
+    '|${innerExpr.trim()}| = ${_formatValue(observed)} $operator ${_formatValue(rightValue)}',
+  );
+}
+
+final RegExp _comparisonRegex =
+    RegExp(r'^\s*([A-Za-z0-9_.]+)\s*(==|!=|<=|>=|<|>)\s*(.+)\s*$');
+
+dynamic _resolveValue(String expr, RuleContext ctx) {
+  final trimmed = expr.trim();
+  if (trimmed.isEmpty) {
+    return null;
+  }
+  if ((trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+      (trimmed.startsWith('"') && trimmed.endsWith('"'))) {
+    return trimmed.substring(1, trimmed.length - 1);
+  }
+  if (trimmed == 'true') return true;
+  if (trimmed == 'false') return false;
+  if (trimmed == 'null') return null;
+
+  final numeric = double.tryParse(trimmed);
+  if (numeric != null) {
+    return trimmed.contains('.') ? numeric : numeric.toInt();
+  }
+
+  if (trimmed == 'repCount') {
+    return ctx.repCount;
+  }
+
+  if (trimmed.startsWith('perf.')) {
+    return _resolvePerfValue(trimmed.substring(5), ctx);
+  }
+
+  if (trimmed.startsWith('cloud_result.')) {
+    return _dig(ctx.cloudResult, trimmed.substring('cloud_result.'.length).split('.'));
+  }
+
+  return _dig(ctx.resultJson, trimmed.split('.'));
+}
+
+double? _resolveNumericExpression(String expr, RuleContext ctx) {
+  final trimmed = expr.trim();
+  final minusIndex = _findTopLevelMinus(trimmed);
+  if (minusIndex != null) {
+    final leftExpr = trimmed.substring(0, minusIndex);
+    final rightExpr = trimmed.substring(minusIndex + 1);
+    final leftVal = _resolveValue(leftExpr, ctx);
+    final rightVal = _resolveValue(rightExpr, ctx);
+    final leftNum = _asDouble(leftVal);
+    final rightNum = _asDouble(rightVal);
+    if (leftNum == null || rightNum == null) {
+      return null;
+    }
+    return leftNum - rightNum;
+  }
+  final single = _resolveValue(trimmed, ctx);
+  return _asDouble(single);
+}
+
+int? _findTopLevelMinus(String expr) {
+  var depth = 0;
+  for (var i = 0; i < expr.length; i++) {
+    final ch = expr[i];
+    if (ch == '(') {
+      depth += 1;
+    } else if (ch == ')') {
+      if (depth > 0) {
+        depth -= 1;
+      }
+    } else if (ch == '-' && depth == 0) {
+      return i;
+    }
+  }
+  return null;
+}
+
+dynamic _resolvePerfValue(String key, RuleContext ctx) {
+  switch (key) {
+    case 'rtf':
+    case 'pipelineRtf':
+      return ctx.perfRtf;
+    case 'memPeakMB':
+      return ctx.perfMemPeakMb;
+    case 'inferenceFps':
+      return ctx.perfInferenceFps;
+    default:
+      final segments = key.split('.');
+      final perf = ctx.perfJson;
+      if (perf == null) {
+        return null;
+      }
+      return _dig(perf, segments);
+  }
+}
+
+dynamic _dig(dynamic root, List<String> segments) {
+  dynamic current = root;
+  for (final segment in segments) {
+    if (current is Map<String, dynamic>) {
+      current = current[segment];
+    } else {
+      return null;
+    }
+  }
+  return current;
+}
+
+bool _compareValues(dynamic left, dynamic right, String operator) {
+  if (operator == '==' || operator == '!=') {
+    final equality = left == right;
+    return operator == '==' ? equality : !equality;
+  }
+
+  final leftNum = _asDouble(left);
+  final rightNum = _asDouble(right);
+  if (leftNum == null || rightNum == null) {
+    return false;
+  }
+  return _compareNumeric(leftNum, rightNum, operator);
+}
+
+bool _compareNumeric(double left, double right, String operator) {
+  switch (operator) {
+    case '<':
+      return left < right;
+    case '<=':
+      return left <= right;
+    case '>':
+      return left > right;
+    case '>=':
+      return left >= right;
+    default:
+      return false;
+  }
+}
+
+double? _asDouble(dynamic value) {
+  if (value is num) {
+    return value.toDouble();
+  }
+  if (value is String) {
+    return double.tryParse(value.trim());
+  }
+  if (value is bool) {
+    return value ? 1.0 : 0.0;
+  }
+  return null;
+}
+
+String _formatValue(dynamic value) {
+  if (value == null) {
+    return 'null';
+  }
+  if (value is num) {
+    return value.toString();
+  }
+  if (value is bool) {
+    return value ? 'true' : 'false';
+  }
+  return value.toString();
+}
+
+int _resolveRepCount(Map<String, dynamic> resultJson) {
+  final direct = resultJson['repCount'];
+  if (direct is num) {
+    return direct.toInt();
+  }
+  final reps = resultJson['reps'];
+  if (reps is List) {
+    return reps.length;
+  }
+  return 0;
+}
+
+File? _locateOutputFile(Directory outDir, String fileName) {
+  final direct = File(_resolvePath(outDir.path, fileName));
+  if (direct.existsSync()) {
+    return direct;
+  }
+  final logsDir = Directory(_resolvePath(outDir.path, 'logs'));
+  final logCandidate = File(_resolvePath(logsDir.path, fileName));
+  if (logCandidate.existsSync()) {
+    return logCandidate;
+  }
+  return null;
+}
+
+String _resolvePath(String base, String relative) {
+  final baseUri = Directory(base).uri;
+  final normalized = relative.replaceAll('\', '/');
+  return baseUri.resolve(normalized).toFilePath();
+}
+
+String _basenameWithoutExtension(String path) {
+  final normalized = path.replaceAll('\', '/');
+  final slash = normalized.lastIndexOf('/');
+  final fileName = slash == -1 ? normalized : normalized.substring(slash + 1);
+  final dot = fileName.lastIndexOf('.');
+  return dot == -1 ? fileName : fileName.substring(0, dot);
+}
+
+String _absoluteFilePath(String path) => File(path).absolute.path;
+
+String _absoluteDirPath(String path) => Directory(path).absolute.path;


### PR DESCRIPTION
## Summary
- add a standalone Dart runner that loads the Milestone C manifest and executes each sample through the aiwa_cli pipeline
- assert the presence of expected artifacts, parse outputs, and evaluate the manifest validation rules with helpful failure summaries
- support configurable paths, selective execution, and verbose logging to integrate with CI workflows

## Testing
- not run (Dart SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68f6f2e0bf74832687e7d5aca7540e77