### PR TITLE
Align examples runner with file-mode samples

### DIFF
--- a/examples/examples_manifest.json
+++ b/examples/examples_manifest.json
@@ -3,8 +3,13 @@
     "sampleId": "squat_normal",
     "category": "正常样本",
     "purpose": "验证主流程在标准光照视频下的输出结构与评分稳定性",
-    "inputs": ["input.mp4"],
-    "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+    "inputs": ["neutral_keypoints.json"],
+    "expectedOutputs": [
+      "neutral_keypoints/result.json",
+      "neutral_keypoints/angles.csv",
+      "neutral_keypoints/evidence.json",
+      "neutral_keypoints/logs/perf.json"
+    ],
     "validationRules": [
       "hybrid.triggered == false",
       "scores.overall >= 90",
@@ -15,22 +20,36 @@
     "sampleId": "squat_occlusion",
     "category": "异常样本",
     "purpose": "验证 Hybrid 触发与云端合并逻辑",
-    "inputs": ["input.mp4", "hybrid_policy.json", "cloud_result.json"],
-    "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+    "inputs": [
+      "neutral_keypoints.json",
+      "hybrid_policy.json",
+      "cloud_result.json"
+    ],
+    "expectedOutputs": [
+      "neutral_keypoints/result.json",
+      "neutral_keypoints/angles.csv",
+      "neutral_keypoints/evidence.json",
+      "neutral_keypoints/logs/perf.json"
+    ],
     "validationRules": [
       "hybrid.triggered == true",
       "hybrid.mergeStrategy == 'prefer-cloud-count-then-reconcile'",
-      "hybrid.delta.countFinal == cloud_result.repCount"
+      "cloud_result.repCount == repCount"
     ]
   },
   {
     "sampleId": "squat_short",
     "category": "性能样本",
     "purpose": "验证超短素材下的启动开销与结果完整性",
-    "inputs": ["input.mp4"],
-    "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+    "inputs": ["neutral_keypoints.json"],
+    "expectedOutputs": [
+      "neutral_keypoints/result.json",
+      "neutral_keypoints/angles.csv",
+      "neutral_keypoints/evidence.json",
+      "neutral_keypoints/logs/perf.json"
+    ],
     "validationRules": [
-      "perf.rtf < 0.5",
+      "perf.pipelineRtf <= 0.5",
       "repCount <= 1",
       "hybrid.triggered == false"
     ]
@@ -39,11 +58,16 @@
     "sampleId": "squat_long",
     "category": "性能样本",
     "purpose": "验证超长素材下的内存峰值与降级策略",
-    "inputs": ["input.mp4"],
-    "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+    "inputs": ["neutral_keypoints.json"],
+    "expectedOutputs": [
+      "neutral_keypoints/result.json",
+      "neutral_keypoints/angles.csv",
+      "neutral_keypoints/evidence.json",
+      "neutral_keypoints/logs/perf.json"
+    ],
     "validationRules": [
       "perf.memPeakMB <= 600",
-      "abs(perf.rtf - 1.0) <= 0.1",
+      "abs(perf.pipelineRtf - 1.0) <= 0.1",
       "repCount >= 70"
     ]
   },
@@ -52,7 +76,12 @@
     "category": "节奏样本",
     "purpose": "检查节奏异常下的评分稳健性",
     "inputs": ["neutral_keypoints.json"],
-    "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+    "expectedOutputs": [
+      "neutral_keypoints/result.json",
+      "neutral_keypoints/angles.csv",
+      "neutral_keypoints/evidence.json",
+      "neutral_keypoints/logs/perf.json"
+    ],
     "validationRules": [
       "issues.any(code == 'TEMPO_VARIATION')",
       "scores.tempo < scores.form",
@@ -64,7 +93,12 @@
     "category": "噪声样本",
     "purpose": "验证关键点噪声时的鲁棒性",
     "inputs": ["neutral_keypoints.json"],
-    "expectedOutputs": ["result.json", "angles.csv", "evidence.json", "perf.json"],
+    "expectedOutputs": [
+      "neutral_keypoints/result.json",
+      "neutral_keypoints/angles.csv",
+      "neutral_keypoints/evidence.json",
+      "neutral_keypoints/logs/perf.json"
+    ],
     "validationRules": [
       "quality.lowConfidence == true",
       "issues.any(code == 'NOISY_LANDMARKS')",

--- a/examples/squat_long/neutral_keypoints.json
+++ b/examples/squat_long/neutral_keypoints.json
@@ -1,0 +1,117 @@
+{
+  "version": "vB1.1",
+  "video": {
+    "fpsIntended": 30,
+    "fps": 29.5,
+    "width": 720,
+    "height": 1280,
+    "durationMs": 360000
+  },
+  "engine": {
+    "name": "mlkit",
+    "model": "blazepose-full",
+    "sdkVersion": "1.3.0"
+  },
+  "sampling": {
+    "stride": 3,
+    "effectiveFps": 9.8
+  },
+  "frames": [
+    {
+      "frameIndex": 0,
+      "timestampMs": 0,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.48, "y": 0.36, "z": -0.08, "score": 0.96},
+        {"name": "rightShoulder", "x": 0.52, "y": 0.36, "z": -0.07, "score": 0.96},
+        {"name": "leftHip", "x": 0.49, "y": 0.64, "z": -0.11, "score": 0.95},
+        {"name": "rightHip", "x": 0.51, "y": 0.64, "z": -0.11, "score": 0.95},
+        {"name": "leftKnee", "x": 0.48, "y": 0.83, "z": -0.09, "score": 0.94},
+        {"name": "rightKnee", "x": 0.52, "y": 0.83, "z": -0.09, "score": 0.94},
+        {"name": "leftAnkle", "x": 0.47, "y": 0.97, "z": -0.05, "score": 0.93},
+        {"name": "rightAnkle", "x": 0.53, "y": 0.97, "z": -0.05, "score": 0.93}
+      ]
+    },
+    {
+      "frameIndex": 45,
+      "timestampMs": 4600,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.47, "y": 0.39, "z": -0.08, "score": 0.95},
+        {"name": "rightShoulder", "x": 0.53, "y": 0.39, "z": -0.07, "score": 0.95},
+        {"name": "leftHip", "x": 0.48, "y": 0.73, "z": -0.14, "score": 0.94},
+        {"name": "rightHip", "x": 0.52, "y": 0.73, "z": -0.14, "score": 0.94},
+        {"name": "leftKnee", "x": 0.46, "y": 0.91, "z": -0.13, "score": 0.93},
+        {"name": "rightKnee", "x": 0.54, "y": 0.91, "z": -0.13, "score": 0.93},
+        {"name": "leftAnkle", "x": 0.45, "y": 1.01, "z": -0.06, "score": 0.92},
+        {"name": "rightAnkle", "x": 0.55, "y": 1.01, "z": -0.06, "score": 0.92}
+      ]
+    },
+    {
+      "frameIndex": 130,
+      "timestampMs": 13200,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.45, "y": 0.46, "z": -0.09, "score": 0.94},
+        {"name": "rightShoulder", "x": 0.55, "y": 0.46, "z": -0.09, "score": 0.94},
+        {"name": "leftHip", "x": 0.47, "y": 0.82, "z": -0.16, "score": 0.93},
+        {"name": "rightHip", "x": 0.53, "y": 0.82, "z": -0.16, "score": 0.93},
+        {"name": "leftKnee", "x": 0.44, "y": 1.00, "z": -0.18, "score": 0.92},
+        {"name": "rightKnee", "x": 0.56, "y": 1.00, "z": -0.18, "score": 0.92},
+        {"name": "leftAnkle", "x": 0.43, "y": 1.05, "z": -0.08, "score": 0.90},
+        {"name": "rightAnkle", "x": 0.57, "y": 1.05, "z": -0.08, "score": 0.90}
+      ]
+    },
+    {
+      "frameIndex": 260,
+      "timestampMs": 26400,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.47, "y": 0.40, "z": -0.08, "score": 0.95},
+        {"name": "rightShoulder", "x": 0.53, "y": 0.40, "z": -0.07, "score": 0.95},
+        {"name": "leftHip", "x": 0.48, "y": 0.74, "z": -0.14, "score": 0.94},
+        {"name": "rightHip", "x": 0.52, "y": 0.74, "z": -0.14, "score": 0.94},
+        {"name": "leftKnee", "x": 0.46, "y": 0.92, "z": -0.13, "score": 0.93},
+        {"name": "rightKnee", "x": 0.54, "y": 0.92, "z": -0.13, "score": 0.93},
+        {"name": "leftAnkle", "x": 0.45, "y": 1.02, "z": -0.06, "score": 0.92},
+        {"name": "rightAnkle", "x": 0.55, "y": 1.02, "z": -0.06, "score": 0.92}
+      ]
+    },
+    {
+      "frameIndex": 520,
+      "timestampMs": 52800,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.46, "y": 0.38, "z": -0.08, "score": 0.95},
+        {"name": "rightShoulder", "x": 0.54, "y": 0.38, "z": -0.07, "score": 0.95},
+        {"name": "leftHip", "x": 0.47, "y": 0.71, "z": -0.13, "score": 0.94},
+        {"name": "rightHip", "x": 0.53, "y": 0.71, "z": -0.13, "score": 0.94},
+        {"name": "leftKnee", "x": 0.45, "y": 0.90, "z": -0.12, "score": 0.93},
+        {"name": "rightKnee", "x": 0.55, "y": 0.90, "z": -0.12, "score": 0.93},
+        {"name": "leftAnkle", "x": 0.44, "y": 1.00, "z": -0.05, "score": 0.92},
+        {"name": "rightAnkle", "x": 0.56, "y": 1.00, "z": -0.05, "score": 0.92}
+      ]
+    },
+    {
+      "frameIndex": 720,
+      "timestampMs": 73200,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.48, "y": 0.36, "z": -0.08, "score": 0.96},
+        {"name": "rightShoulder", "x": 0.52, "y": 0.36, "z": -0.07, "score": 0.96},
+        {"name": "leftHip", "x": 0.49, "y": 0.64, "z": -0.11, "score": 0.95},
+        {"name": "rightHip", "x": 0.51, "y": 0.64, "z": -0.11, "score": 0.95},
+        {"name": "leftKnee", "x": 0.48, "y": 0.83, "z": -0.09, "score": 0.94},
+        {"name": "rightKnee", "x": 0.52, "y": 0.83, "z": -0.09, "score": 0.94},
+        {"name": "leftAnkle", "x": 0.47, "y": 0.97, "z": -0.05, "score": 0.93},
+        {"name": "rightAnkle", "x": 0.53, "y": 0.97, "z": -0.05, "score": 0.93}
+      ]
+    }
+  ]
+}

--- a/examples/squat_noisy_keypoints/neutral_keypoints.json
+++ b/examples/squat_noisy_keypoints/neutral_keypoints.json
@@ -2,6 +2,7 @@
   "version": "vB1.1",
   "video": {
     "fpsIntended": 30,
+    "fps": 29.7,
     "width": 720,
     "height": 1280,
     "durationMs": 3200
@@ -13,7 +14,7 @@
   },
   "sampling": {
     "stride": 2,
-    "effectiveFps": 15.0
+    "effectiveFps": 14.8
   },
   "frames": [
     {
@@ -22,18 +23,30 @@
       "lowConfidence": false,
       "mirrorApplied": false,
       "keypoints": [
-        {"name": "leftKnee", "x": 0.45, "y": 0.64, "z": -0.05, "score": 0.93},
-        {"name": "rightKnee", "x": 0.55, "y": 0.63, "z": -0.04, "score": 0.94}
+        {"name": "leftShoulder", "x": 0.47, "y": 0.35, "z": -0.08, "score": 0.95},
+        {"name": "rightShoulder", "x": 0.53, "y": 0.35, "z": -0.07, "score": 0.95},
+        {"name": "leftHip", "x": 0.48, "y": 0.64, "z": -0.11, "score": 0.94},
+        {"name": "rightHip", "x": 0.52, "y": 0.64, "z": -0.11, "score": 0.94},
+        {"name": "leftKnee", "x": 0.47, "y": 0.83, "z": -0.09, "score": 0.93},
+        {"name": "rightKnee", "x": 0.53, "y": 0.83, "z": -0.09, "score": 0.93},
+        {"name": "leftAnkle", "x": 0.46, "y": 0.97, "z": -0.05, "score": 0.92},
+        {"name": "rightAnkle", "x": 0.54, "y": 0.97, "z": -0.05, "score": 0.92}
       ]
     },
     {
       "frameIndex": 8,
       "timestampMs": 520,
-      "lowConfidence": false,
+      "lowConfidence": true,
       "mirrorApplied": false,
       "keypoints": [
-        {"name": "leftKnee", "x": 0.43, "y": 0.78, "z": -0.12, "score": 0.58},
-        {"name": "rightKnee", "x": 0.57, "y": 0.79, "z": -0.11, "score": 0.62}
+        {"name": "leftShoulder", "x": 0.46, "y": 0.40, "z": -0.08, "score": 0.74},
+        {"name": "rightShoulder", "x": 0.55, "y": 0.41, "z": -0.07, "score": 0.70},
+        {"name": "leftHip", "x": 0.46, "y": 0.74, "z": -0.14, "score": 0.68},
+        {"name": "rightHip", "x": 0.54, "y": 0.76, "z": -0.16, "score": 0.64},
+        {"name": "leftKnee", "x": 0.44, "y": 0.93, "z": -0.15, "score": 0.62},
+        {"name": "rightKnee", "x": 0.57, "y": 0.95, "z": -0.17, "score": 0.59},
+        {"name": "leftAnkle", "x": 0.43, "y": 1.02, "z": -0.08, "score": 0.55},
+        {"name": "rightAnkle", "x": 0.59, "y": 1.03, "z": -0.10, "score": 0.52}
       ]
     },
     {
@@ -42,8 +55,14 @@
       "lowConfidence": true,
       "mirrorApplied": false,
       "keypoints": [
-        {"name": "leftKnee", "x": 0.44, "y": 0.85, "z": -0.18, "score": 0.29},
-        {"name": "rightKnee", "x": 0.56, "y": 0.87, "z": -0.17, "score": 0.27}
+        {"name": "leftShoulder", "x": 0.45, "y": 0.45, "z": -0.09, "score": 0.58},
+        {"name": "rightShoulder", "x": 0.56, "y": 0.46, "z": -0.09, "score": 0.55},
+        {"name": "leftHip", "x": 0.45, "y": 0.82, "z": -0.18, "score": 0.52},
+        {"name": "rightHip", "x": 0.58, "y": 0.86, "z": -0.20, "score": 0.49},
+        {"name": "leftKnee", "x": 0.42, "y": 1.00, "z": -0.19, "score": 0.46},
+        {"name": "rightKnee", "x": 0.60, "y": 1.03, "z": -0.21, "score": 0.44},
+        {"name": "leftAnkle", "x": 0.40, "y": 1.07, "z": -0.10, "score": 0.40},
+        {"name": "rightAnkle", "x": 0.63, "y": 1.09, "z": -0.13, "score": 0.38}
       ]
     },
     {
@@ -52,8 +71,14 @@
       "lowConfidence": false,
       "mirrorApplied": false,
       "keypoints": [
-        {"name": "leftKnee", "x": 0.42, "y": 0.70, "z": -0.09, "score": 0.72},
-        {"name": "rightKnee", "x": 0.58, "y": 0.71, "z": -0.08, "score": 0.75}
+        {"name": "leftShoulder", "x": 0.46, "y": 0.39, "z": -0.08, "score": 0.94},
+        {"name": "rightShoulder", "x": 0.54, "y": 0.39, "z": -0.07, "score": 0.94},
+        {"name": "leftHip", "x": 0.47, "y": 0.71, "z": -0.13, "score": 0.93},
+        {"name": "rightHip", "x": 0.53, "y": 0.71, "z": -0.13, "score": 0.93},
+        {"name": "leftKnee", "x": 0.45, "y": 0.89, "z": -0.12, "score": 0.92},
+        {"name": "rightKnee", "x": 0.55, "y": 0.89, "z": -0.12, "score": 0.92},
+        {"name": "leftAnkle", "x": 0.44, "y": 0.99, "z": -0.05, "score": 0.91},
+        {"name": "rightAnkle", "x": 0.56, "y": 0.99, "z": -0.05, "score": 0.91}
       ]
     },
     {
@@ -62,8 +87,14 @@
       "lowConfidence": false,
       "mirrorApplied": false,
       "keypoints": [
-        {"name": "leftKnee", "x": 0.45, "y": 0.68, "z": -0.07, "score": 0.88},
-        {"name": "rightKnee", "x": 0.55, "y": 0.69, "z": -0.06, "score": 0.90}
+        {"name": "leftShoulder", "x": 0.47, "y": 0.36, "z": -0.08, "score": 0.96},
+        {"name": "rightShoulder", "x": 0.53, "y": 0.36, "z": -0.07, "score": 0.96},
+        {"name": "leftHip", "x": 0.48, "y": 0.64, "z": -0.11, "score": 0.95},
+        {"name": "rightHip", "x": 0.52, "y": 0.64, "z": -0.11, "score": 0.95},
+        {"name": "leftKnee", "x": 0.47, "y": 0.83, "z": -0.09, "score": 0.94},
+        {"name": "rightKnee", "x": 0.53, "y": 0.83, "z": -0.09, "score": 0.94},
+        {"name": "leftAnkle", "x": 0.46, "y": 0.97, "z": -0.05, "score": 0.93},
+        {"name": "rightAnkle", "x": 0.54, "y": 0.97, "z": -0.05, "score": 0.93}
       ]
     }
   ]

--- a/examples/squat_normal/neutral_keypoints.json
+++ b/examples/squat_normal/neutral_keypoints.json
@@ -1,0 +1,101 @@
+{
+  "version": "vB1.1",
+  "video": {
+    "fpsIntended": 30,
+    "fps": 30,
+    "width": 720,
+    "height": 1280,
+    "durationMs": 3200
+  },
+  "engine": {
+    "name": "mlkit",
+    "model": "blazepose-full",
+    "sdkVersion": "1.3.0"
+  },
+  "sampling": {
+    "stride": 2,
+    "effectiveFps": 15.0
+  },
+  "frames": [
+    {
+      "frameIndex": 0,
+      "timestampMs": 0,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.46, "y": 0.35, "z": -0.08, "score": 0.97},
+        {"name": "rightShoulder", "x": 0.54, "y": 0.35, "z": -0.07, "score": 0.97},
+        {"name": "leftHip", "x": 0.47, "y": 0.63, "z": -0.10, "score": 0.96},
+        {"name": "rightHip", "x": 0.53, "y": 0.63, "z": -0.10, "score": 0.96},
+        {"name": "leftKnee", "x": 0.46, "y": 0.82, "z": -0.08, "score": 0.95},
+        {"name": "rightKnee", "x": 0.54, "y": 0.82, "z": -0.08, "score": 0.95},
+        {"name": "leftAnkle", "x": 0.45, "y": 0.96, "z": -0.04, "score": 0.94},
+        {"name": "rightAnkle", "x": 0.55, "y": 0.96, "z": -0.04, "score": 0.94}
+      ]
+    },
+    {
+      "frameIndex": 8,
+      "timestampMs": 520,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.45, "y": 0.37, "z": -0.08, "score": 0.97},
+        {"name": "rightShoulder", "x": 0.55, "y": 0.37, "z": -0.07, "score": 0.97},
+        {"name": "leftHip", "x": 0.46, "y": 0.70, "z": -0.13, "score": 0.96},
+        {"name": "rightHip", "x": 0.54, "y": 0.70, "z": -0.13, "score": 0.96},
+        {"name": "leftKnee", "x": 0.44, "y": 0.88, "z": -0.12, "score": 0.94},
+        {"name": "rightKnee", "x": 0.56, "y": 0.89, "z": -0.12, "score": 0.94},
+        {"name": "leftAnkle", "x": 0.44, "y": 0.98, "z": -0.05, "score": 0.93},
+        {"name": "rightAnkle", "x": 0.56, "y": 0.98, "z": -0.05, "score": 0.93}
+      ]
+    },
+    {
+      "frameIndex": 16,
+      "timestampMs": 1040,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.44, "y": 0.44, "z": -0.09, "score": 0.96},
+        {"name": "rightShoulder", "x": 0.56, "y": 0.44, "z": -0.08, "score": 0.96},
+        {"name": "leftHip", "x": 0.45, "y": 0.78, "z": -0.16, "score": 0.95},
+        {"name": "rightHip", "x": 0.55, "y": 0.78, "z": -0.16, "score": 0.95},
+        {"name": "leftKnee", "x": 0.43, "y": 0.96, "z": -0.17, "score": 0.94},
+        {"name": "rightKnee", "x": 0.57, "y": 0.96, "z": -0.17, "score": 0.94},
+        {"name": "leftAnkle", "x": 0.43, "y": 1.00, "z": -0.07, "score": 0.92},
+        {"name": "rightAnkle", "x": 0.57, "y": 1.00, "z": -0.07, "score": 0.92}
+      ]
+    },
+    {
+      "frameIndex": 28,
+      "timestampMs": 1820,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.45, "y": 0.38, "z": -0.08, "score": 0.97},
+        {"name": "rightShoulder", "x": 0.55, "y": 0.38, "z": -0.07, "score": 0.97},
+        {"name": "leftHip", "x": 0.46, "y": 0.69, "z": -0.13, "score": 0.96},
+        {"name": "rightHip", "x": 0.54, "y": 0.69, "z": -0.13, "score": 0.96},
+        {"name": "leftKnee", "x": 0.44, "y": 0.88, "z": -0.12, "score": 0.95},
+        {"name": "rightKnee", "x": 0.56, "y": 0.88, "z": -0.12, "score": 0.95},
+        {"name": "leftAnkle", "x": 0.44, "y": 0.99, "z": -0.05, "score": 0.94},
+        {"name": "rightAnkle", "x": 0.56, "y": 0.99, "z": -0.05, "score": 0.94}
+      ]
+    },
+    {
+      "frameIndex": 40,
+      "timestampMs": 2600,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.46, "y": 0.35, "z": -0.08, "score": 0.97},
+        {"name": "rightShoulder", "x": 0.54, "y": 0.35, "z": -0.07, "score": 0.97},
+        {"name": "leftHip", "x": 0.47, "y": 0.63, "z": -0.10, "score": 0.96},
+        {"name": "rightHip", "x": 0.53, "y": 0.63, "z": -0.10, "score": 0.96},
+        {"name": "leftKnee", "x": 0.46, "y": 0.82, "z": -0.08, "score": 0.95},
+        {"name": "rightKnee", "x": 0.54, "y": 0.82, "z": -0.08, "score": 0.95},
+        {"name": "leftAnkle", "x": 0.45, "y": 0.96, "z": -0.04, "score": 0.94},
+        {"name": "rightAnkle", "x": 0.55, "y": 0.96, "z": -0.04, "score": 0.94}
+      ]
+    }
+  ]
+}

--- a/examples/squat_occlusion/neutral_keypoints.json
+++ b/examples/squat_occlusion/neutral_keypoints.json
@@ -1,0 +1,101 @@
+{
+  "version": "vB1.1",
+  "video": {
+    "fpsIntended": 30,
+    "fps": 28.5,
+    "width": 720,
+    "height": 1280,
+    "durationMs": 3600
+  },
+  "engine": {
+    "name": "mlkit",
+    "model": "blazepose-full",
+    "sdkVersion": "1.3.0"
+  },
+  "sampling": {
+    "stride": 2,
+    "effectiveFps": 14.2
+  },
+  "frames": [
+    {
+      "frameIndex": 0,
+      "timestampMs": 0,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.47, "y": 0.36, "z": -0.09, "score": 0.95},
+        {"name": "rightShoulder", "x": 0.53, "y": 0.36, "z": -0.08, "score": 0.95},
+        {"name": "leftHip", "x": 0.48, "y": 0.65, "z": -0.11, "score": 0.94},
+        {"name": "rightHip", "x": 0.52, "y": 0.65, "z": -0.11, "score": 0.94},
+        {"name": "leftKnee", "x": 0.47, "y": 0.84, "z": -0.09, "score": 0.93},
+        {"name": "rightKnee", "x": 0.53, "y": 0.84, "z": -0.09, "score": 0.93},
+        {"name": "leftAnkle", "x": 0.46, "y": 0.97, "z": -0.05, "score": 0.92},
+        {"name": "rightAnkle", "x": 0.54, "y": 0.97, "z": -0.05, "score": 0.92}
+      ]
+    },
+    {
+      "frameIndex": 10,
+      "timestampMs": 700,
+      "lowConfidence": true,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.46, "y": 0.40, "z": -0.08, "score": 0.74},
+        {"name": "rightShoulder", "x": 0.55, "y": 0.41, "z": -0.07, "score": 0.58},
+        {"name": "leftHip", "x": 0.46, "y": 0.75, "z": -0.15, "score": 0.70},
+        {"name": "rightHip", "x": 0.55, "y": 0.78, "z": -0.18, "score": 0.51},
+        {"name": "leftKnee", "x": 0.44, "y": 0.93, "z": -0.16, "score": 0.66},
+        {"name": "rightKnee", "x": 0.58, "y": 0.95, "z": -0.19, "score": 0.42},
+        {"name": "leftAnkle", "x": 0.43, "y": 1.00, "z": -0.08, "score": 0.61},
+        {"name": "rightAnkle", "x": 0.60, "y": 1.00, "z": -0.12, "score": 0.39}
+      ]
+    },
+    {
+      "frameIndex": 18,
+      "timestampMs": 1260,
+      "lowConfidence": true,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.45, "y": 0.45, "z": -0.09, "score": 0.68},
+        {"name": "rightShoulder", "x": 0.56, "y": 0.47, "z": -0.09, "score": 0.36},
+        {"name": "leftHip", "x": 0.45, "y": 0.83, "z": -0.18, "score": 0.63},
+        {"name": "rightHip", "x": 0.58, "y": 0.87, "z": -0.21, "score": 0.34},
+        {"name": "leftKnee", "x": 0.42, "y": 1.00, "z": -0.21, "score": 0.59},
+        {"name": "rightKnee", "x": 0.61, "y": 1.00, "z": -0.24, "score": 0.31},
+        {"name": "leftAnkle", "x": 0.40, "y": 1.05, "z": -0.11, "score": 0.54},
+        {"name": "rightAnkle", "x": 0.64, "y": 1.07, "z": -0.15, "score": 0.28}
+      ]
+    },
+    {
+      "frameIndex": 30,
+      "timestampMs": 2100,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.46, "y": 0.38, "z": -0.09, "score": 0.94},
+        {"name": "rightShoulder", "x": 0.54, "y": 0.38, "z": -0.08, "score": 0.93},
+        {"name": "leftHip", "x": 0.47, "y": 0.72, "z": -0.14, "score": 0.92},
+        {"name": "rightHip", "x": 0.53, "y": 0.73, "z": -0.14, "score": 0.89},
+        {"name": "leftKnee", "x": 0.45, "y": 0.90, "z": -0.13, "score": 0.91},
+        {"name": "rightKnee", "x": 0.55, "y": 0.91, "z": -0.14, "score": 0.87},
+        {"name": "leftAnkle", "x": 0.44, "y": 1.00, "z": -0.06, "score": 0.89},
+        {"name": "rightAnkle", "x": 0.56, "y": 1.00, "z": -0.07, "score": 0.86}
+      ]
+    },
+    {
+      "frameIndex": 44,
+      "timestampMs": 3080,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.47, "y": 0.35, "z": -0.09, "score": 0.95},
+        {"name": "rightShoulder", "x": 0.53, "y": 0.35, "z": -0.08, "score": 0.94},
+        {"name": "leftHip", "x": 0.48, "y": 0.64, "z": -0.11, "score": 0.94},
+        {"name": "rightHip", "x": 0.52, "y": 0.64, "z": -0.11, "score": 0.93},
+        {"name": "leftKnee", "x": 0.47, "y": 0.82, "z": -0.09, "score": 0.93},
+        {"name": "rightKnee", "x": 0.53, "y": 0.82, "z": -0.09, "score": 0.92},
+        {"name": "leftAnkle", "x": 0.46, "y": 0.97, "z": -0.05, "score": 0.91},
+        {"name": "rightAnkle", "x": 0.54, "y": 0.97, "z": -0.05, "score": 0.91}
+      ]
+    }
+  ]
+}

--- a/examples/squat_short/neutral_keypoints.json
+++ b/examples/squat_short/neutral_keypoints.json
@@ -1,0 +1,101 @@
+{
+  "version": "vB1.1",
+  "video": {
+    "fpsIntended": 30,
+    "fps": 29.8,
+    "width": 720,
+    "height": 1280,
+    "durationMs": 1400
+  },
+  "engine": {
+    "name": "mlkit",
+    "model": "blazepose-full",
+    "sdkVersion": "1.3.0"
+  },
+  "sampling": {
+    "stride": 1,
+    "effectiveFps": 29.8
+  },
+  "frames": [
+    {
+      "frameIndex": 0,
+      "timestampMs": 0,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.47, "y": 0.34, "z": -0.08, "score": 0.96},
+        {"name": "rightShoulder", "x": 0.53, "y": 0.34, "z": -0.07, "score": 0.96},
+        {"name": "leftHip", "x": 0.48, "y": 0.62, "z": -0.10, "score": 0.95},
+        {"name": "rightHip", "x": 0.52, "y": 0.62, "z": -0.10, "score": 0.95},
+        {"name": "leftKnee", "x": 0.47, "y": 0.80, "z": -0.08, "score": 0.94},
+        {"name": "rightKnee", "x": 0.53, "y": 0.80, "z": -0.08, "score": 0.94},
+        {"name": "leftAnkle", "x": 0.46, "y": 0.95, "z": -0.04, "score": 0.93},
+        {"name": "rightAnkle", "x": 0.54, "y": 0.95, "z": -0.04, "score": 0.93}
+      ]
+    },
+    {
+      "frameIndex": 5,
+      "timestampMs": 170,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.46, "y": 0.39, "z": -0.08, "score": 0.95},
+        {"name": "rightShoulder", "x": 0.54, "y": 0.39, "z": -0.07, "score": 0.95},
+        {"name": "leftHip", "x": 0.47, "y": 0.71, "z": -0.13, "score": 0.94},
+        {"name": "rightHip", "x": 0.53, "y": 0.71, "z": -0.13, "score": 0.94},
+        {"name": "leftKnee", "x": 0.45, "y": 0.89, "z": -0.12, "score": 0.93},
+        {"name": "rightKnee", "x": 0.55, "y": 0.89, "z": -0.12, "score": 0.93},
+        {"name": "leftAnkle", "x": 0.44, "y": 0.99, "z": -0.05, "score": 0.92},
+        {"name": "rightAnkle", "x": 0.56, "y": 0.99, "z": -0.05, "score": 0.92}
+      ]
+    },
+    {
+      "frameIndex": 11,
+      "timestampMs": 370,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.45, "y": 0.45, "z": -0.09, "score": 0.94},
+        {"name": "rightShoulder", "x": 0.55, "y": 0.45, "z": -0.09, "score": 0.94},
+        {"name": "leftHip", "x": 0.46, "y": 0.80, "z": -0.16, "score": 0.93},
+        {"name": "rightHip", "x": 0.54, "y": 0.80, "z": -0.16, "score": 0.93},
+        {"name": "leftKnee", "x": 0.44, "y": 0.98, "z": -0.17, "score": 0.92},
+        {"name": "rightKnee", "x": 0.56, "y": 0.98, "z": -0.17, "score": 0.92},
+        {"name": "leftAnkle", "x": 0.43, "y": 1.02, "z": -0.07, "score": 0.90},
+        {"name": "rightAnkle", "x": 0.57, "y": 1.02, "z": -0.07, "score": 0.90}
+      ]
+    },
+    {
+      "frameIndex": 17,
+      "timestampMs": 580,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.46, "y": 0.39, "z": -0.08, "score": 0.95},
+        {"name": "rightShoulder", "x": 0.54, "y": 0.39, "z": -0.07, "score": 0.95},
+        {"name": "leftHip", "x": 0.47, "y": 0.71, "z": -0.13, "score": 0.94},
+        {"name": "rightHip", "x": 0.53, "y": 0.71, "z": -0.13, "score": 0.94},
+        {"name": "leftKnee", "x": 0.45, "y": 0.89, "z": -0.12, "score": 0.93},
+        {"name": "rightKnee", "x": 0.55, "y": 0.89, "z": -0.12, "score": 0.93},
+        {"name": "leftAnkle", "x": 0.44, "y": 0.99, "z": -0.05, "score": 0.92},
+        {"name": "rightAnkle", "x": 0.56, "y": 0.99, "z": -0.05, "score": 0.92}
+      ]
+    },
+    {
+      "frameIndex": 23,
+      "timestampMs": 790,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.47, "y": 0.34, "z": -0.08, "score": 0.96},
+        {"name": "rightShoulder", "x": 0.53, "y": 0.34, "z": -0.07, "score": 0.96},
+        {"name": "leftHip", "x": 0.48, "y": 0.62, "z": -0.10, "score": 0.95},
+        {"name": "rightHip", "x": 0.52, "y": 0.62, "z": -0.10, "score": 0.95},
+        {"name": "leftKnee", "x": 0.47, "y": 0.80, "z": -0.08, "score": 0.94},
+        {"name": "rightKnee", "x": 0.53, "y": 0.80, "z": -0.08, "score": 0.94},
+        {"name": "leftAnkle", "x": 0.46, "y": 0.95, "z": -0.04, "score": 0.93},
+        {"name": "rightAnkle", "x": 0.54, "y": 0.95, "z": -0.04, "score": 0.93}
+      ]
+    }
+  ]
+}

--- a/examples/squat_tempo_irregular/neutral_keypoints.json
+++ b/examples/squat_tempo_irregular/neutral_keypoints.json
@@ -2,6 +2,7 @@
   "version": "vB1.1",
   "video": {
     "fpsIntended": 30,
+    "fps": 30,
     "width": 720,
     "height": 1280,
     "durationMs": 4200
@@ -22,38 +23,78 @@
       "lowConfidence": false,
       "mirrorApplied": false,
       "keypoints": [
-        {"name": "leftHip", "x": 0.48, "y": 0.72, "z": -0.12, "score": 0.92},
-        {"name": "rightHip", "x": 0.52, "y": 0.72, "z": -0.10, "score": 0.94}
+        {"name": "leftShoulder", "x": 0.46, "y": 0.35, "z": -0.08, "score": 0.96},
+        {"name": "rightShoulder", "x": 0.54, "y": 0.35, "z": -0.07, "score": 0.96},
+        {"name": "leftHip", "x": 0.47, "y": 0.63, "z": -0.11, "score": 0.95},
+        {"name": "rightHip", "x": 0.53, "y": 0.63, "z": -0.11, "score": 0.95},
+        {"name": "leftKnee", "x": 0.46, "y": 0.82, "z": -0.09, "score": 0.94},
+        {"name": "rightKnee", "x": 0.54, "y": 0.82, "z": -0.09, "score": 0.94},
+        {"name": "leftAnkle", "x": 0.45, "y": 0.96, "z": -0.05, "score": 0.93},
+        {"name": "rightAnkle", "x": 0.55, "y": 0.96, "z": -0.05, "score": 0.93}
       ]
     },
     {
       "frameIndex": 6,
-      "timestampMs": 400,
+      "timestampMs": 360,
       "lowConfidence": false,
       "mirrorApplied": false,
       "keypoints": [
-        {"name": "leftHip", "x": 0.47, "y": 0.80, "z": -0.16, "score": 0.91},
-        {"name": "rightHip", "x": 0.53, "y": 0.83, "z": -0.18, "score": 0.90}
+        {"name": "leftShoulder", "x": 0.45, "y": 0.38, "z": -0.08, "score": 0.95},
+        {"name": "rightShoulder", "x": 0.55, "y": 0.38, "z": -0.07, "score": 0.95},
+        {"name": "leftHip", "x": 0.46, "y": 0.72, "z": -0.14, "score": 0.94},
+        {"name": "rightHip", "x": 0.54, "y": 0.73, "z": -0.15, "score": 0.93},
+        {"name": "leftKnee", "x": 0.44, "y": 0.90, "z": -0.13, "score": 0.92},
+        {"name": "rightKnee", "x": 0.56, "y": 0.91, "z": -0.14, "score": 0.92},
+        {"name": "leftAnkle", "x": 0.43, "y": 0.99, "z": -0.06, "score": 0.91},
+        {"name": "rightAnkle", "x": 0.57, "y": 0.99, "z": -0.06, "score": 0.91}
       ]
     },
     {
       "frameIndex": 18,
-      "timestampMs": 1200,
+      "timestampMs": 1800,
       "lowConfidence": true,
       "mirrorApplied": false,
       "keypoints": [
-        {"name": "leftHip", "x": 0.48, "y": 0.86, "z": -0.20, "score": 0.42},
-        {"name": "rightHip", "x": 0.52, "y": 0.89, "z": -0.22, "score": 0.40}
+        {"name": "leftShoulder", "x": 0.44, "y": 0.46, "z": -0.09, "score": 0.65},
+        {"name": "rightShoulder", "x": 0.56, "y": 0.48, "z": -0.10, "score": 0.62},
+        {"name": "leftHip", "x": 0.45, "y": 0.86, "z": -0.18, "score": 0.60},
+        {"name": "rightHip", "x": 0.58, "y": 0.90, "z": -0.22, "score": 0.55},
+        {"name": "leftKnee", "x": 0.42, "y": 1.02, "z": -0.20, "score": 0.58},
+        {"name": "rightKnee", "x": 0.60, "y": 1.05, "z": -0.23, "score": 0.54},
+        {"name": "leftAnkle", "x": 0.40, "y": 1.08, "z": -0.11, "score": 0.52},
+        {"name": "rightAnkle", "x": 0.63, "y": 1.10, "z": -0.14, "score": 0.49}
+      ]
+    },
+    {
+      "frameIndex": 28,
+      "timestampMs": 2600,
+      "lowConfidence": false,
+      "mirrorApplied": false,
+      "keypoints": [
+        {"name": "leftShoulder", "x": 0.45, "y": 0.38, "z": -0.08, "score": 0.95},
+        {"name": "rightShoulder", "x": 0.55, "y": 0.38, "z": -0.07, "score": 0.95},
+        {"name": "leftHip", "x": 0.46, "y": 0.69, "z": -0.13, "score": 0.94},
+        {"name": "rightHip", "x": 0.54, "y": 0.69, "z": -0.13, "score": 0.94},
+        {"name": "leftKnee", "x": 0.44, "y": 0.88, "z": -0.12, "score": 0.93},
+        {"name": "rightKnee", "x": 0.56, "y": 0.88, "z": -0.12, "score": 0.93},
+        {"name": "leftAnkle", "x": 0.43, "y": 0.99, "z": -0.05, "score": 0.92},
+        {"name": "rightAnkle", "x": 0.57, "y": 0.99, "z": -0.05, "score": 0.92}
       ]
     },
     {
       "frameIndex": 44,
-      "timestampMs": 2800,
+      "timestampMs": 3600,
       "lowConfidence": false,
       "mirrorApplied": false,
       "keypoints": [
-        {"name": "leftHip", "x": 0.49, "y": 0.74, "z": -0.11, "score": 0.95},
-        {"name": "rightHip", "x": 0.51, "y": 0.74, "z": -0.11, "score": 0.96}
+        {"name": "leftShoulder", "x": 0.47, "y": 0.35, "z": -0.08, "score": 0.96},
+        {"name": "rightShoulder", "x": 0.53, "y": 0.35, "z": -0.07, "score": 0.96},
+        {"name": "leftHip", "x": 0.48, "y": 0.63, "z": -0.11, "score": 0.95},
+        {"name": "rightHip", "x": 0.52, "y": 0.63, "z": -0.11, "score": 0.95},
+        {"name": "leftKnee", "x": 0.47, "y": 0.82, "z": -0.09, "score": 0.94},
+        {"name": "rightKnee", "x": 0.53, "y": 0.82, "z": -0.09, "score": 0.94},
+        {"name": "leftAnkle", "x": 0.46, "y": 0.96, "z": -0.05, "score": 0.93},
+        {"name": "rightAnkle", "x": 0.54, "y": 0.96, "z": -0.05, "score": 0.93}
       ]
     }
   ]

--- a/tools/examples_runner.dart
+++ b/tools/examples_runner.dart
@@ -59,9 +59,9 @@ Options:
   --dry-run            Preview commands without executing the CLI.
   --evidence-config    Override evidence config path.
   --cue-map            Override cue map path.
-  * Provide either neutral_keypoints.json or input.mp4 for each sample.
+  * Provide neutral_keypoints.json for each sample (CLI file mode only).
   * Outputs are written to <out>/<sampleId>/ (sampleId-based folders).
-  * Video samples default to engine "mlkit" unless overridden.
+  * Video/engine mode is only available in the Flutter app builds.
   -h, --help           Show this help message.
 
 Examples:
@@ -519,7 +519,20 @@ class ExamplesRunner {
       );
     }
 
-    final resultFile = producedFiles['result.json'];
+    File? _firstBySuffix(String suffix) {
+      final normalizedSuffix = suffix.replaceAll('\\', '/');
+      final matches = producedFiles.entries
+          .where((entry) =>
+              entry.key.replaceAll('\\', '/').endsWith(normalizedSuffix))
+          .toList(growable: false);
+      if (matches.isEmpty) {
+        return null;
+      }
+      matches.sort((a, b) => a.key.compareTo(b.key));
+      return matches.first.value;
+    }
+
+    final resultFile = _firstBySuffix('result.json');
     if (resultFile == null) {
       return SampleRunResult.failure(
         sampleId: spec.sampleId,
@@ -532,8 +545,9 @@ class ExamplesRunner {
         outputDirEntries: artifactListing,
       );
     }
-    final expectsPerf = spec.expectedOutputs.contains('perf.json');
-    final perfFile = expectsPerf ? producedFiles['perf.json'] : null;
+    final expectsPerf =
+        spec.expectedOutputs.any((path) => path.endsWith('perf.json'));
+    final perfFile = expectsPerf ? _firstBySuffix('perf.json') : null;
 
     Map<String, dynamic> resultJson;
     try {
@@ -1066,12 +1080,51 @@ File? _locateOutputFile(Directory outDir, String fileName) {
   if (direct.existsSync()) {
     return direct;
   }
-  final logsDir = Directory(_resolvePath(outDir.path, 'logs'));
-  final logCandidate = File(_resolvePath(logsDir.path, fileName));
-  if (logCandidate.existsSync()) {
-    return logCandidate;
+
+  final normalizedExpected = fileName.replaceAll('\\', '/');
+  final expectedSegments = normalizedExpected
+      .split('/')
+      .where((segment) => segment.isNotEmpty)
+      .toList(growable: false);
+
+  bool endsWithSegments(String relativePath) {
+    final normalized = relativePath.replaceAll('\\', '/');
+    if (normalized == normalizedExpected) {
+      return true;
+    }
+    final candidateSegments = normalized
+        .split('/')
+        .where((segment) => segment.isNotEmpty)
+        .toList(growable: false);
+    if (expectedSegments.length > candidateSegments.length) {
+      return false;
+    }
+    for (var i = 0; i < expectedSegments.length; i++) {
+      final candidateIndex = candidateSegments.length - expectedSegments.length + i;
+      if (candidateSegments[candidateIndex] != expectedSegments[i]) {
+        return false;
+      }
+    }
+    return true;
   }
-  return null;
+
+  final matches = <File>[];
+  for (final entity in outDir.listSync(recursive: true, followLinks: false)) {
+    if (entity is! File) {
+      continue;
+    }
+    final relative = _relativePath(outDir.path, entity.path);
+    if (endsWithSegments(relative)) {
+      matches.add(entity);
+    }
+  }
+
+  if (matches.isEmpty) {
+    return null;
+  }
+
+  matches.sort((a, b) => a.path.compareTo(b.path));
+  return matches.first;
 }
 
 void _printStreamSummary(String label, List<String> lines) {


### PR DESCRIPTION
## Summary
- add vB1.1-compliant neutral keypoint inputs for every squat sample so the CLI can run in file mode
- update the examples manifest to point at the new inputs, expected output paths, and refreshed validation rules
- enhance the examples runner to locate nested outputs and clarify that it operates in keypoint file mode

## Testing
- ⚠️ `dart format tools/examples_runner.dart` *(failed: Dart SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f77c1303cc83268f5d01827bc5a065