### PR TITLE
docs: reorganize documentation center and add architecture overview

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,309 +1,71 @@
 # AIWA 项目文档中心
 
-欢迎查阅 AIWA（AI Workout Assistant）项目文档中心。本目录包含了项目的所有技术文档，按照阶段和功能进行了分类整理。
+欢迎查阅 AIWA（AI Workout Assistant）项目文档中心。本目录收录了项目的全部设计、规范、实施与运维资料，并按照主题分类，便于在不同交付阶段快速检索。
 
 ---
 
-## 📚 文档目录结构
+## 🗂️ 目录导航
 
-### 00-project/ - 项目总体文档
-项目架构、总结和核心说明文档
+### 00-project / project — 项目基础档案
+- **[project/architecture.md](project/architecture.md)**：当前分支的整体系统架构、组件边界与数据流向。
+- **[00-project/project_summary.md](00-project/project_summary.md)**：阶段性交付总结、完成事项与统计。
+- **[00-project/agents.md](00-project/agents.md)**：AIWA Squat Offline Pipeline 的项目说明、依赖与目录索引。
 
-- **[architecture.md](00-project/architecture.md)** - AIWA 项目系统架构
-  - 系统架构图、CI/CD 流程图、数据流图
-  - 目录结构树、组件依赖关系
-  - 测试架构、技术栈层次
-  
-- **[project_summary.md](00-project/project_summary.md)** - AIWA 项目完成总结
-  - 项目概览、完成任务清单
-  - 项目统计、文档索引
-  - 技术栈、最佳实践、项目成就
-  
-- **[agents.md](00-project/agents.md)** - 项目说明（AIWA Squat Offline Pipeline）
-  - 项目概述、包结构
-  - 安装与运行、构建指南
-  - 目录结构、技术栈、贡献指南
+### 01-design — 设计文档
+- **[evidence_design.md](01-design/evidence_design.md)**：证据化（Evidence Pipeline）设计规范。
+- **[hybrid_design.md](01-design/hybrid_design.md)**：Hybrid 占位流程设计说明。
+- **[evidence_pipeline.md](01-design/evidence_pipeline.md)**：证据生成流程细节。
+- **[merge_rules.md](01-design/merge_rules.md)**：合并规则说明。
+- **[perf_privacy_budget.md](01-design/perf_privacy_budget.md)**、**[evidence_perf_privacy_budget.md](01-design/evidence_perf_privacy_budget.md)**：性能与隐私预算。
 
----
+### 02-specifications — 规范与契约
+- **[schema_milestone_b.md](02-specifications/schema_milestone_b.md)**：Milestone B 输出规范。
+- **[alignment_contract.md](02-specifications/alignment_contract.md)**：关键点语义对齐契约。
+- **[rule_spec_v0.1.md](02-specifications/rule_spec_v0.1.md)**：规则规范。
+- **[theme_boundary_compliance.md](02-specifications/theme_boundary_compliance.md)**、**[quick_start_boundary.md](02-specifications/quick_start_boundary.md)**：主题与快速开始边界约定。
 
-### 01-design/ - 设计文档
-核心算法与流程设计说明
+### 03-guides — 安装与使用指南
+- **[cli_usage.md](03-guides/cli_usage.md)**：Hybrid & Evidence CLI 参数说明。
+- **[environment_config.md](03-guides/environment_config.md)**：环境变量配置指南与常见问题。
+- **[tools_quick_start.md](03-guides/tools_quick_start.md)**、**[tool_quick_start.md](03-guides/tool_quick_start.md)**：工具快速开始。
+- **[movenet_quick_start.md](03-guides/movenet_quick_start.md)**、**[event_bus_quick_start.md](03-guides/event_bus_quick_start.md)**：关键子系统使用指南。
+- **[config_sync_guide.md](03-guides/config_sync_guide.md)**、**[adapters_guide.md](03-guides/adapters_guide.md)**：配置同步与适配器使用说明。
 
-- **[evidence_design.md](01-design/evidence_design.md)** - 证据化（Evidence Pipeline）规范
-  - 设计说明、证据生成策略
-  - 数据契约、生成流程
-  - cue→建议映射表、验收标准
-  
-- **[hybrid_design.md](01-design/hybrid_design.md)** - Hybrid 占位流程设计
-  - 触发器、上行路径、合并策略
-  - 关键指标定义、触发判定规则
-  - 上行包约束、性能预算、隐私策略
-  
-- **[evidence_pipeline.md](01-design/evidence_pipeline.md)** - 证据生成流程详细文档
-  
-- **[merge_rules.md](01-design/merge_rules.md)** - 合并规则说明
-  
-- **[perf_privacy_budget.md](01-design/perf_privacy_budget.md)** - 性能与隐私预算
-  
-- **[evidence_perf_privacy_budget.md](01-design/evidence_perf_privacy_budget.md)** - 证据流程性能与隐私预算
+### 04-reports — 交付与验收报告
+- 核心功能实现：如 **[cancellation_token_implementation_report.md](04-reports/cancellation_token_implementation_report.md)**、**[movenet_implementation.md](04-reports/movenet_implementation.md)** 等。
+- 页面/功能实现：如 **[analysis_history_implementation.md](04-reports/analysis_history_implementation.md)**、**[pages_optimization_summary.md](04-reports/pages_optimization_summary.md)**。
+- 服务与适配器交付：如 **[services_implementation_summary.md](04-reports/services_implementation_summary.md)**、**[adapters_delivery.md](04-reports/adapters_delivery.md)**。
+- 其他阶段报告：如 **[ci_cd_complete.md](04-reports/ci_cd_complete.md)**、**[figma_theme_generation_summary.md](04-reports/figma_theme_generation_summary.md)**。
 
----
+### 05-testing — 测试计划与结果
+- **[COMPLETE_TESTING_REPORT.md](05-testing/COMPLETE_TESTING_REPORT.md)**：全量测试报告。
+- **[TEST_SUMMARY_PHASE3.md](05-testing/TEST_SUMMARY_PHASE3.md)**：Phase 3 测试总结与覆盖率。
+- **[evidence_e2e_plan.md](05-testing/evidence_e2e_plan.md)**、**[hybrid_e2e_plan.md](05-testing/hybrid_e2e_plan.md)**：端到端测试计划。
 
-### 02-specifications/ - 规范与契约
-项目规范、Schema 定义和边界约定
+### 06-validation — 验证规则
+- **[validation_rules.md](06-validation/validation_rules.md)**：通用验证规则。
+- **[evidence_validation_rules.md](06-validation/evidence_validation_rules.md)**：证据流程专用验证。
 
-- **[schema_milestone_b.md](02-specifications/schema_milestone_b.md)** - Milestone B 输出规范文档（vB1.1）
-  - neutral_keypoints.json Schema
-  - result.json 增量字段
-  - 输出目录规范、校验清单
-  
-- **[alignment_contract.md](02-specifications/alignment_contract.md)** - 对齐契约
-  - 关键点语义对齐规范
-  
-- **[rule_spec_v0.1.md](02-specifications/rule_spec_v0.1.md)** - 规则规范 v0.1
-  
-- **[theme_boundary_compliance.md](02-specifications/theme_boundary_compliance.md)** - 主题边界合规性
-  
-- **[quick_start_boundary.md](02-specifications/quick_start_boundary.md)** - 快速开始边界约定
+### 07-cloud — 云平台交付
+- **[ARCHITECTURE_OVERVIEW.md](07-cloud/ARCHITECTURE_OVERVIEW.md)**：云端架构与组件边界。
+- **[CLOUD_CORE_API.md](07-cloud/CLOUD_CORE_API.md)**：核心 API 说明。
+- **[WORKER_CONTRACT.md](07-cloud/WORKER_CONTRACT.md)**、**[DATA_SCHEMAS.md](07-cloud/DATA_SCHEMAS.md)**：云端工人协议与数据结构。
+- **[PLAN_VALIDATION_REPORT.md](07-cloud/PLAN_VALIDATION_REPORT.md)**、**[project_phase_summary.md](07-cloud/project_phase_summary.md)**：阶段总结与上线计划。
 
----
+### perf — 性能预算
+- **[BUDGET.md](perf/BUDGET.md)**：性能指标、设备分级与预算。
 
-### 03-guides/ - 使用指南
-安装、配置和使用教程
+### protocols — 协议与对接契约
+- **[readme.md](protocols/readme.md)**：协议合集索引。
+- **[ERROR_TO_ACTION.md](protocols/ERROR_TO_ACTION.md)**、**[INTEGRATION_CHECKLIST.md](protocols/INTEGRATION_CHECKLIST.md)**：集成与异常处理规范。
+- **schemas/**：结果、性能、运行时等 JSON Schema 定义。
 
-- **[cli_usage.md](03-guides/cli_usage.md)** - Hybrid & Evidence CLI 使用与参数说明
-  - Hybrid 参数、Evidence 参数
-  - 控制台输出格式、输出文件
-  
-- **[environment_config.md](03-guides/environment_config.md)** - 环境变量配置指南
-  - 快速开始、详细配置说明
-  - Supabase 配置示例、安全建议
-  - 常见问题解答
-  
-- **[tools_quick_start.md](03-guides/tools_quick_start.md)** - 工具快速开始指南
-
-- **[movenet_quick_start.md](03-guides/movenet_quick_start.md)** - MoveNet 快速开始指南
-  - 模型下载、配置引擎、使用说明
-  
-- **[event_bus_quick_start.md](03-guides/event_bus_quick_start.md)** - Event Bus 快速开始指南
-  - 事件流服务使用教程
-  
-- **[tool_quick_start.md](03-guides/tool_quick_start.md)** - 工具快速开始指南
-  
-- **[config_sync_guide.md](03-guides/config_sync_guide.md)** - 配置同步使用指南
-  
-- **[adapters_guide.md](03-guides/adapters_guide.md)** - 适配器使用指南
+### 根目录与其他文档
+- **[USER_GUIDE.md](USER_GUIDE.md)**：最终用户使用说明。
+- **[RELEASE_NOTES.md](RELEASE_NOTES.md)**：版本变更与发布记录。
+- **[ORGANIZATION_SUMMARY.md](ORGANIZATION_SUMMARY.md)**：组织交付摘要。
+- 统一取消令牌架构实施报告、Figma 主题总结等补充材料位于仓库根目录。
 
 ---
 
-### 04-reports/ - 完成报告
-项目各阶段完成报告和总结
-
-#### 核心功能实现报告
-- **[cancellation_token_implementation_report.md](04-reports/cancellation_token_implementation_report.md)** - 统一取消令牌架构实施报告
-  
-- **[auth_integration_report.md](04-reports/auth_integration_report.md)** - 认证功能集成报告
-  
-- **[movenet_implementation.md](04-reports/movenet_implementation.md)** - MoveNet 姿态检测实现文档
-  
-- **[native_implementation.md](04-reports/native_implementation.md)** - 原生实现完成报告
-  
-- **[native_frame_extraction.md](04-reports/native_frame_extraction.md)** - 原生帧提取实现报告
-  
-- **[eventchannel_implementation.md](04-reports/eventchannel_implementation.md)** - EventChannel 实现完成报告
-
-#### 页面与功能实现报告
-- **[analysis_history_implementation.md](04-reports/analysis_history_implementation.md)** - 分析历史功能实现报告
-  
-- **[camera_layout_fix.md](04-reports/camera_layout_fix.md)** - 相机页面布局修复报告
-  
-- **[CAMERA_PAGE_FIX_SUMMARY.md](04-reports/CAMERA_PAGE_FIX_SUMMARY.md)** - 相机页面修复总结
-  
-- **[pages_optimization_summary.md](04-reports/pages_optimization_summary.md)** - 页面优化总结
-  
-- **[result_popup_dod.md](04-reports/result_popup_dod.md)** - 结果弹窗完成标准
-  
-- **[settings_page_dod.md](04-reports/settings_page_dod.md)** - 设置页面完成标准
-
-#### 其他功能实现报告
-- **[surface_mode_implementation.md](04-reports/surface_mode_implementation.md)** - Surface 模式实现报告
-  
-- **[surface_mode_code_review.md](04-reports/surface_mode_code_review.md)** - Surface 模式代码审查
-  
-- **[mirror_export_feature.md](04-reports/mirror_export_feature.md)** - 镜像导出功能报告
-  
-- **[tflite_version_fix.md](04-reports/tflite_version_fix.md)** - TFLite 版本修复报告
-
-#### 测试相关报告
-- **[testing_improvements_summary.md](04-reports/testing_improvements_summary.md)** - 测试改进总结
-  
-- **[testing_native_frame_extraction.md](04-reports/testing_native_frame_extraction.md)** - 原生帧提取测试报告
-
-#### 服务与适配器交付报告
-- **[services_implementation_summary.md](04-reports/services_implementation_summary.md)** - 服务层实现总结
-  
-- **[services_delivery.md](04-reports/services_delivery.md)** - 服务层交付报告
-  
-- **[config_sync_delivery.md](04-reports/config_sync_delivery.md)** - 配置同步交付报告
-  
-- **[adapters_delivery.md](04-reports/adapters_delivery.md)** - 适配器交付报告
-
-#### 其他阶段报告
-- **[low_priority_tasks_summary.md](04-reports/low_priority_tasks_summary.md)** - 低优先级任务总结
-  
-- **[ci_cd_complete.md](04-reports/ci_cd_complete.md)** - CI/CD 完成报告
-  
-- **[tokens_sync_complete.md](04-reports/tokens_sync_complete.md)** - Tokens 同步完成报告
-  
-- **[figma_theme_complete.md](04-reports/figma_theme_complete.md)** - Figma 主题完成报告
-  
-- **[figma_theme_generation_summary.md](04-reports/figma_theme_generation_summary.md)** - Figma 主题生成总结
-  
-- **[figma_mcp_test_results.md](04-reports/figma_mcp_test_results.md)** - Figma MCP 测试结果
-  
-- **[nav_implementation_report.md](04-reports/nav_implementation_report.md)** - 导航实现报告
-  
-- **[final_acceptance_report.md](04-reports/final_acceptance_report.md)** - 最终验收报告
-  
-- **[implementation_summary.md](04-reports/implementation_summary.md)** - 实现总结
-  
-- **[PHASE3_FIX_IMPLEMENTATION_REPORT.md](04-reports/PHASE3_FIX_IMPLEMENTATION_REPORT.md)** - Phase 3 修复实施报告
-  
-- **[PHASE4_IMPLEMENTATION_SUMMARY.md](04-reports/PHASE4_IMPLEMENTATION_SUMMARY.md)** - Phase 4 实现总结
-  
-- **[PHASE5_HARDENING_SUMMARY.md](04-reports/PHASE5_HARDENING_SUMMARY.md)** - Phase 5 加固总结
-  
-- **[sync_tokens_report.md](04-reports/sync_tokens_report.md)** - Tokens 同步报告
-  
-- **[theme_generation_report.md](04-reports/theme_generation_report.md)** - 主题生成报告
-
----
-
-### 05-testing/ - 测试文档
-端到端测试计划和测试规范
-
-- **[hybrid_e2e_plan.md](05-testing/hybrid_e2e_plan.md)** - Hybrid 端到端测试计划
-  
-- **[evidence_e2e_plan.md](05-testing/evidence_e2e_plan.md)** - Evidence 端到端测试计划
-
----
-
-### 06-validation/ - 验证规则
-数据验证和质量检查规则
-
-- **[validation_rules.md](06-validation/validation_rules.md)** - 验证规则
-  
-- **[evidence_validation_rules.md](06-validation/evidence_validation_rules.md)** - Evidence 验证规则
-
----
-
-### 07-cloud/ - 云端相关
-云端平台相关文档
-
-- **[project_phase_summary.md](07-cloud/project_phase_summary.md)** - 云端平台阶段性总结
-  - 项目架构搭建、核心功能实现
-  - 数据库设计、UI/UX 设计
-  - 项目完成度评估
-  
-- **[file_organization.md](07-cloud/file_organization.md)** - 云端项目文件整理清单
-  - 已删除/修改/新增文件列表
-  - 项目文件结构、整理效果
-  - 安全性提升、项目健康度检查
-  
-- **[cloud_app_readme.md](07-cloud/cloud_app_readme.md)** - 云端应用 README
-
----
-
-## 🗂️ 其他资源
-
-### 示例数据
-- `cloud_mock_examples/` - 云端模拟数据示例
-  - `cloud_conflict.json` - 冲突场景示例
-  - `cloud_extra.json` - 额外数据示例
-  - `cloud_refine.json` - 细化结果示例
-
-### 配置契约
-- `cloud_payload_contract.json` - 云端负载契约定义
-
----
-
-## 📖 快速导航
-
-### 🚀 新手入门
-1. [项目说明](00-project/agents.md) - 了解项目概述
-2. [架构文档](00-project/architecture.md) - 理解系统架构
-3. [CLI 使用指南](03-guides/cli_usage.md) - 开始使用 CLI
-4. [环境配置](03-guides/environment_config.md) - 配置开发环境
-
-### 🔧 开发参考
-1. [Schema 规范](02-specifications/schema_milestone_b.md) - 数据格式规范
-2. [Evidence 设计](01-design/evidence_design.md) - 证据流程设计
-3. [Hybrid 设计](01-design/hybrid_design.md) - 混合流程设计
-4. [验证规则](06-validation/validation_rules.md) - 数据验证规则
-
-### 📊 项目状态
-1. [项目总结](00-project/project_summary.md) - 总体完成情况
-2. [完成报告](04-reports/) - 各阶段完成报告
-3. [测试计划](05-testing/) - 测试覆盖情况
-
----
-
-## 📝 文档维护
-
-### 文档更新原则
-- **准确性**：确保文档与代码实现保持同步
-- **完整性**：覆盖所有重要的功能和配置
-- **可读性**：使用清晰的语言和结构化的格式
-- **时效性**：及时更新文档以反映最新变更
-
-### 文档分类标准
-- **00-project**：项目级别的总体文档
-- **01-design**：算法和流程的设计文档
-- **02-specifications**：规范、Schema 和契约
-- **03-guides**：面向用户的使用指南
-- **04-reports**：阶段性完成报告
-- **05-testing**：测试相关文档
-- **06-validation**：验证规则和检查清单
-- **07-cloud**：云端平台专属文档
-
----
-
-## 🔗 相关链接
-
-- 主项目 README：[../README.md](../README.md)
-- aiwa_core：[../aiwa_core/](../aiwa_core/)
-- aiwa_cli：[../aiwa_cli/](../aiwa_cli/)
-- aiwa_app：[../aiwa_app/](../aiwa_app/)
-- 配置文件：[../configs/](../configs/)
-- Schema 定义：[../schemas/](../schemas/)
-- 示例数据：[../examples/](../examples/)
-
----
-
-## ❓ 获取帮助
-
-如果您在使用文档时遇到问题：
-
-1. 查看相关章节的"常见问题"部分
-2. 检查示例代码和配置文件
-3. 参考项目 README 中的"贡献指南"
-4. 联系项目维护者
-
----
-
-**文档整理日期**：2025年1月  
-**文档版本**：v1.1  
-**维护者**：AIWA 项目团队
-
----
-
-## 📝 更新日志
-
-### v1.1 (2025年1月)
-- 新增 25+ 个实施报告文档
-- 新增 5 个使用指南文档
-- 优化文档分类结构
-- 完善文档索引
-
-
-
+如需新增文档，请按上述分类将文件放置到对应目录，并在本索引中同步更新，确保团队成员可快速定位。

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -1,0 +1,85 @@
+# AIWA 系统架构（当前分支）
+
+本页记录当前分支的整体系统形态，串联本地离线分析、移动端推理、云端扩展以及支撑文档，便于在不同交付场景下快速定位职责与依赖。
+
+## 1. 组件全景
+
+```
+┌───────────────────────────────────────────────────────────────────────┐
+│                              AIWA 平台                               │
+├──────────────────┬────────────────────────┬───────────────────────────┤
+│ 终端推理层       │ 核心分析与工具层       │ 云端扩展层                │
+│ (Flutter/Dart)   │ (纯 Dart)              │ (Node/Infra)              │
+├──────────────────┼────────────────────────┼───────────────────────────┤
+│ • aiwa_app       │ • aiwa_core            │ • aiwa_cloud / docs/07    │
+│   - UI/主题      │   - OfflinePipeline    │   - Core API, S3, SQS     │
+│   - Pose Engines │   - 规则/计数/质量     │   - Worker Contracts      │
+│   - Cloud API    │ • aiwa_cli             │                           │
+│ • aiwa_runner    │   - 命令行入口         │                           │
+│   - 帧抽取/镜像  │   - 性能预算守护       │                           │
+└──────────────────┴────────────────────────┴───────────────────────────┘
+```
+
+- **aiwa_app**：面向终端用户，封装姿态引擎选择、证据降级策略和云端 API 客户端。
+- **aiwa_runner**：在移动端/模拟器中批量处理视频帧，调用核心离线流水线并导出结果。
+- **aiwa_core**：实现姿态序列过滤、角度计算、计数、质量评估及证据生成，是离线与云端的共享内核。【F:aiwa_core/lib/pipeline/offline_pipeline.dart†L1-L200】
+- **aiwa_cli**：面向开发/验收的命令行工具，包装 `aiwa_core` 并提供性能守护与多项输出检查。【F:aiwa_cli/bin/aiwa_cli.dart†L1-L160】
+- **aiwa_cloud**：提供会话管理、资产存储与后台推理的服务化实现，详细结构见云端文档。【F:docs/07-cloud/ARCHITECTURE_OVERVIEW.md†L1-L133】
+
+## 2. 核心模块职责
+
+### aiwa_core — 离线分析内核
+- `OfflinePipeline` 负责关键点过滤、角度计算、阶段分段、计数和质量评估，并导出 `angles.csv` 与结构化 `result.json` 证据。【F:aiwa_core/lib/pipeline/offline_pipeline.dart†L22-L199】
+- 统一的规则模型 (`RuleSet`)、严格度配置和指标阈值支撑不同强度的训练场景。【F:aiwa_core/lib/pipeline/offline_pipeline.dart†L89-L145】
+
+### aiwa_cli — 命令行与验收工具
+- 作为 Dart CLI 入口，直接依赖 `aiwa_core` 的 IO、姿态序列和规则解析模块，提供关键点解析、规则加载与性能计时。【F:aiwa_cli/bin/aiwa_cli.dart†L10-L57】
+- 内建性能守护：监控实时性、内存、温度，并在严格模式下触发告警或退出码，用于端到端验收。【F:aiwa_cli/bin/aiwa_cli.dart†L65-L156】
+
+### aiwa_runner — 移动端离线编排器
+- 管理应用工作目录、输入/规则/日志结构，并在内部与外部存储之间同步素材与结果，便于调试与 `adb pull`。【F:aiwa_runner/lib/runner_orchestrator.dart†L62-L134】
+- 负责任务调度：枚举帧、调用 ML Kit 推理、构建中立关键点序列并交由 `OfflinePipeline` 生成证据。【F:aiwa_runner/lib/runner_orchestrator.dart†L136-L200】
+
+### aiwa_app — 终端应用
+- 通过 `PoseEngineFactory` 选择不同的姿态引擎（ML Kit / MoveNet / Auto），统一暴露 `PoseEngine` 接口供 UI 与服务层使用。【F:aiwa_app/lib/pose/pose_engine_factory.dart†L1-L86】
+- `EvidenceResolver` 根据协议降级策略解析快照或时间窗，确保 UI 可以容错展示训练证据。【F:aiwa_app/lib/adapters/evidence_resolver.dart†L1-L106】
+- `ApiClient` 统一处理云端 API 的鉴权、请求头、超时与错误封装，为会话上传和结果拉取提供基础设施。【F:aiwa_app/lib/services/api_client.dart†L1-L120】
+
+### aiwa_cloud — 云平台交付
+a. **Core API Service**：暴露 `/v1/auth`, `/v1/sessions`, `/v1/jobs`，使用 JWT 进行会话管理并协调 S3 资产与 SQS 任务队列。
+b. **Worker Services**：`REINFER` 与 `ADVICE` Worker 从队列消费任务，产出云端推理结果。
+c. **存储与数据库**：Supabase PostgreSQL 存储用户/作业状态，S3 保存关键点、视频与分析结果，DLQ 保障失败任务可追踪。
+> 详细结构见云端架构图及组件边界说明。【F:docs/07-cloud/ARCHITECTURE_OVERVIEW.md†L1-L133】
+
+## 3. 数据流
+
+### 3.1 离线分析流程
+1. **素材准备**：`aiwa_runner` 将视频与规则复制到工作空间，并定位内部/外部帧目录，缺失时提示先抽帧。【F:aiwa_runner/lib/runner_orchestrator.dart†L76-L153】
+2. **姿态推理**：通过 ML Kit 逐帧推理生成中立关键点，统计推理耗时与质量指标。【F:aiwa_runner/lib/runner_orchestrator.dart†L166-L200】
+3. **核心计算**：`OfflinePipeline` 滤波关键点 → 角度计算 → 阶段分段 → 次数统计 → 质量指标 → 证据汇总，最终输出 `angles.csv` 与 `result.json`。【F:aiwa_core/lib/pipeline/offline_pipeline.dart†L29-L199】
+4. **命令行模式**：`aiwa_cli` 复用相同管线，扩展性能守护、导出目录和退出码体系，便于自动化 CI 验证。【F:aiwa_cli/bin/aiwa_cli.dart†L31-L156】
+
+### 3.2 云端协同流程
+1. 移动 App 通过 `ApiClient` 完成鉴权、上传关键点/视频至 S3（预签名 URL），并在 Core API 中创建/更新 Session。
+2. Core API 将任务投递至 SQS，`REINFER` / `ADVICE` Worker 处理后将结果写回 S3，并更新数据库状态。
+3. App 轮询或推送获取云端增强结果，与本地离线结果合并呈现。
+> 详细时序、权限与安全边界参考云端架构文档。【F:docs/07-cloud/ARCHITECTURE_OVERVIEW.md†L98-L133】
+
+## 4. 部署与运行模式
+- **本地开发**：使用 `aiwa_cli` 调试规则与关键点数据，结合 docs/05-testing 的端到端计划执行 CI 验收。
+- **移动离线**：`aiwa_runner` 与 `aiwa_app` 的离线路径共享 `aiwa_core` 内核，确保移动端无需网络即可完成一次完整分析。
+- **云端增强**：当需同步至后端或获取 AI 建议时，通过 `aiwa_app` 的 API 客户端接入 `aiwa_cloud` 服务，并遵守 docs/protocols 的 schema 与错误处理规范。【F:aiwa_app/lib/services/api_client.dart†L1-L120】【F:docs/protocols/ui_contracts.md†L1-L120】
+
+## 5. 协议与输出契约
+- 证据降级策略与 UI 契约：`EvidenceResolver` 按 `docs/protocols/ui_contracts.md` 解析快照/时间窗，保证前端一致性。【F:aiwa_app/lib/adapters/evidence_resolver.dart†L1-L106】
+- 结果与性能 Schema：位于 `docs/protocols/schemas/`，在 CLI、App 与云端间共享，确保导出的 `result.json`、性能指标具备验证依据。
+
+## 6. 仓库目录速览
+- `aiwa_core/`：核心算法、规则与测试。
+- `aiwa_cli/`：CLI 入口与默认配置。
+- `aiwa_app/`：Flutter 应用（UI、服务、适配器、主题）。
+- `aiwa_runner/`：Milestone B 离线 Runner。
+- `aiwa_cloud/`：部署脚本、Core API、Worker 规范。
+- `docs/`：文档中心（参见 [docs/README.md](../README.md)）。
+
+如需扩展或替换某一层，请在对应模块补充文档并更新本页，保持架构信息同步。


### PR DESCRIPTION
## Summary
- reorganize the documentation center index to cover every documentation category
- add a system-wide architecture overview in docs/project/architecture.md tying together core, app, runner, CLI, and cloud components

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_690bedee6de88320ac654e2f952344b5