### PR TITLE
Normalize keypoint names and reuse aiwa_core utilities

### DIFF
--- a/aiwa_app/lib/pose/per_joint_threshold.dart
+++ b/aiwa_app/lib/pose/per_joint_threshold.dart
@@ -9,6 +9,7 @@
 // - 符合生理先验：躯干稳定，远端易遮挡
 
 import 'package:aiwa_core/pose/pose_engine.dart';
+import 'package:aiwa_core/pose/keypoint_names.dart';
 
 /// 关节组类型
 enum JointGroup {
@@ -60,10 +61,6 @@ class PerJointThresholdFilter {
     'rightShoulder': JointGroup.core,
     'leftHip': JointGroup.core,
     'rightHip': JointGroup.core,
-    'left_shoulder': JointGroup.core,
-    'right_shoulder': JointGroup.core,
-    'left_hip': JointGroup.core,
-    'right_hip': JointGroup.core,
 
     // 主要关节
     'leftElbow': JointGroup.major,
@@ -72,12 +69,6 @@ class PerJointThresholdFilter {
     'rightKnee': JointGroup.major,
     'leftAnkle': JointGroup.major,
     'rightAnkle': JointGroup.major,
-    'left_elbow': JointGroup.major,
-    'right_elbow': JointGroup.major,
-    'left_knee': JointGroup.major,
-    'right_knee': JointGroup.major,
-    'left_ankle': JointGroup.major,
-    'right_ankle': JointGroup.major,
 
     // 外围关节
     'leftWrist': JointGroup.peripheral,
@@ -92,18 +83,6 @@ class PerJointThresholdFilter {
     'rightHeel': JointGroup.peripheral,
     'leftFootIndex': JointGroup.peripheral,
     'rightFootIndex': JointGroup.peripheral,
-    'left_wrist': JointGroup.peripheral,
-    'right_wrist': JointGroup.peripheral,
-    'left_pinky': JointGroup.peripheral,
-    'right_pinky': JointGroup.peripheral,
-    'left_index': JointGroup.peripheral,
-    'right_index': JointGroup.peripheral,
-    'left_thumb': JointGroup.peripheral,
-    'right_thumb': JointGroup.peripheral,
-    'left_heel': JointGroup.peripheral,
-    'right_heel': JointGroup.peripheral,
-    'left_foot_index': JointGroup.peripheral,
-    'right_foot_index': JointGroup.peripheral,
 
     // 面部
     'nose': JointGroup.peripheral,
@@ -115,21 +94,16 @@ class PerJointThresholdFilter {
     'rightEyeInner': JointGroup.peripheral,
     'leftEyeOuter': JointGroup.peripheral,
     'rightEyeOuter': JointGroup.peripheral,
-    'left_eye': JointGroup.peripheral,
-    'right_eye': JointGroup.peripheral,
-    'left_ear': JointGroup.peripheral,
-    'right_ear': JointGroup.peripheral,
-    'left_eye_inner': JointGroup.peripheral,
-    'right_eye_inner': JointGroup.peripheral,
-    'left_eye_outer': JointGroup.peripheral,
-    'right_eye_outer': JointGroup.peripheral,
+    'leftMouth': JointGroup.peripheral,
+    'rightMouth': JointGroup.peripheral,
   };
 
   PerJointThresholdFilter(this.config);
 
   /// 根据关节名称获取阈值
   double getThresholdForJoint(String jointName) {
-    final group = _jointGroupMap[jointName] ?? JointGroup.peripheral;
+    final normalized = normalizeNeutralKeypointName(jointName);
+    final group = _jointGroupMap[normalized] ?? JointGroup.peripheral;
     switch (group) {
       case JointGroup.core:
         return config.coreThreshold;

--- a/aiwa_app/lib/services/analysis/video_analysis_service.dart
+++ b/aiwa_app/lib/services/analysis/video_analysis_service.dart
@@ -30,6 +30,7 @@ import 'package:aiwa_core/pose/pose_engine.dart';
 import 'package:aiwa_core/pipeline/offline_pipeline.dart';
 import 'package:aiwa_core/pipeline/pose_input_converter.dart';
 import 'package:aiwa_core/pose/neutral_keypoint_series.dart';
+import 'package:aiwa_core/pose/keypoint_names.dart';
 import 'package:aiwa_core/spec/rule_models.dart';
 import 'package:aiwa_core/spec/rule_parser.dart';
 
@@ -895,16 +896,16 @@ class VideoAnalysisService {
     required int frameIndex,
     required int timestampMs,
   }) {
-    final keypoints = <Map<String, dynamic>>[];
-    for (final name in _kNeutralKeypointNames) {
-      keypoints.add({
-        'name': name,
-        'x': 0.5,
-        'y': 0.5,
-        'z': 0.0,
-        'score': 0.0,
-      });
-    }
+    final keypoints = <Map<String, dynamic>>[
+      for (final name in kNeutralKeypointNames)
+        {
+          'name': name,
+          'x': 0.5,
+          'y': 0.5,
+          'z': 0.0,
+          'score': 0.0,
+        }
+    ];
 
     return {
       'frameIndex': frameIndex,
@@ -1207,43 +1208,4 @@ class VideoAnalysisService {
     }
   }
 
-  /// 中立格式关键点名称（33 个点）
-  static const List<String> _kNeutralKeypointNames = [
-    'nose',
-    'left_eye_inner',
-    'left_eye',
-    'left_eye_outer',
-    'right_eye_inner',
-    'right_eye',
-    'right_eye_outer',
-    'left_ear',
-    'right_ear',
-    'mouth_left',
-    'mouth_right',
-    'left_shoulder',
-    'right_shoulder',
-    'left_elbow',
-    'right_elbow',
-    'left_wrist',
-    'right_wrist',
-    'left_pinky',
-    'right_pinky',
-    'left_index',
-    'right_index',
-    'left_thumb',
-    'right_thumb',
-    'left_hip',
-    'right_hip',
-    'left_knee',
-    'right_knee',
-    'left_ankle',
-    'right_ankle',
-    'left_heel',
-    'right_heel',
-    'left_foot_index',
-    'right_foot_index',
-  ];
-
-  // 🔧 已移除：_kMlKitToNeutralMap 映射已不再使用
-  // 现在使用 keypoint_adapter.dart 中的 adaptMlKitPose 函数进行转换
 }

--- a/aiwa_app/lib/services/visualization/keypoint_overlay_generator.dart
+++ b/aiwa_app/lib/services/visualization/keypoint_overlay_generator.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as p;
 
 import 'package:aiwa_app/services/native/native_video_encoder.dart';
 import 'package:aiwa_app/services/visualization/keypoint_skeleton.dart';
+import 'package:aiwa_core/pose/keypoint_names.dart';
 
 /// Generator for creating keypoint overlay videos
 class KeypointOverlayGenerator {
@@ -86,12 +87,12 @@ class KeypointOverlayGenerator {
       if (i < frames.length) {
         final frameJson = frames[i] as Map<String, dynamic>;
         final keypoints = frameJson['keypoints'] as List<dynamic>;
-        
+
         // Convert keypoints to format expected by encoder
         final keypointsList = keypoints.map((kp) {
           final kpMap = kp as Map<String, dynamic>;
           return {
-            'name': kpMap['name'] as String,
+            'name': normalizeNeutralKeypointName(kpMap['name'] as String),
             'x': (kpMap['x'] as num).toDouble(),
             'y': (kpMap['y'] as num).toDouble(),
             'score': (kpMap['score'] as num).toDouble(),

--- a/aiwa_app/lib/services/visualization/keypoint_skeleton.dart
+++ b/aiwa_app/lib/services/visualization/keypoint_skeleton.dart
@@ -5,6 +5,8 @@
 
 import 'dart:ui';
 
+import 'package:aiwa_core/pose/keypoint_names.dart';
+
 /// Represents a connection between two keypoints (a "bone")
 class SkeletonConnection {
   final String startPoint;
@@ -255,46 +257,9 @@ class KeypointSkeleton {
   
   /// Get serializable connection data for native platform
   static List<Map<String, dynamic>> getConnectionsForNative() {
-    // MLKit 适配器输出的名称为驼峰式，这里将连接表中的 snake_case 映射为驼峰式
-    const Map<String, String> alias = {
-      'nose': 'nose',
-      'left_eye_inner': 'leftEyeInner',
-      'left_eye': 'leftEye',
-      'left_eye_outer': 'leftEyeOuter',
-      'right_eye_inner': 'rightEyeInner',
-      'right_eye': 'rightEye',
-      'right_eye_outer': 'rightEyeOuter',
-      'left_ear': 'leftEar',
-      'right_ear': 'rightEar',
-      'mouth_left': 'leftMouth',
-      'mouth_right': 'rightMouth',
-      'left_shoulder': 'leftShoulder',
-      'right_shoulder': 'rightShoulder',
-      'left_elbow': 'leftElbow',
-      'right_elbow': 'rightElbow',
-      'left_wrist': 'leftWrist',
-      'right_wrist': 'rightWrist',
-      'left_pinky': 'leftPinky',
-      'right_pinky': 'rightPinky',
-      'left_index': 'leftIndex',
-      'right_index': 'rightIndex',
-      'left_thumb': 'leftThumb',
-      'right_thumb': 'rightThumb',
-      'left_hip': 'leftHip',
-      'right_hip': 'rightHip',
-      'left_knee': 'leftKnee',
-      'right_knee': 'rightKnee',
-      'left_ankle': 'leftAnkle',
-      'right_ankle': 'rightAnkle',
-      'left_heel': 'leftHeel',
-      'right_heel': 'rightHeel',
-      'left_foot_index': 'leftFootIndex',
-      'right_foot_index': 'rightFootIndex',
-    };
-
     return connections.map((conn) {
-      final start = alias[conn.startPoint] ?? conn.startPoint;
-      final end = alias[conn.endPoint] ?? conn.endPoint;
+      final start = normalizeNeutralKeypointName(conn.startPoint);
+      final end = normalizeNeutralKeypointName(conn.endPoint);
       return {
         'start': start,
         'end': end,

--- a/aiwa_core/lib/pose/keypoint_names.dart
+++ b/aiwa_core/lib/pose/keypoint_names.dart
@@ -82,3 +82,47 @@ const List<String> kPrimaryTrunkJoints = [
   kLeftHip,
   kRightHip,
 ];
+
+String _toSnakeCase(String input) {
+  final buffer = StringBuffer();
+  for (var i = 0; i < input.length; i++) {
+    final ch = input[i];
+    final isUpper = ch.toUpperCase() == ch && ch.toLowerCase() != ch;
+    if (isUpper && i != 0) {
+      buffer.write('_');
+    }
+    buffer.write(ch.toLowerCase());
+  }
+  return buffer.toString();
+}
+
+final Map<String, String> _neutralSnakeToCamel = {
+  for (final name in kNeutralKeypointNames) _toSnakeCase(name): name,
+  for (final name in kMoveNet17Names) _toSnakeCase(name): name,
+  'mouth_left': 'leftMouth',
+  'mouth_right': 'rightMouth',
+};
+
+/// Normalize a neutral keypoint name to the canonical camelCase form used by
+/// aiwa_core. Accepts legacy snake_case variants and returns the original name
+/// when no canonical mapping is known.
+String normalizeNeutralKeypointName(String name) {
+  if (kNeutralKeypointNameSet.contains(name)) {
+    return name;
+  }
+
+  final lower = name.toLowerCase();
+  final alias = _neutralSnakeToCamel[lower];
+  if (alias != null) {
+    return alias;
+  }
+
+  final sanitized = lower.replaceAll('-', '_');
+  final sanitizedAlias = _neutralSnakeToCamel[sanitized];
+  if (sanitizedAlias != null) {
+    return sanitizedAlias;
+  }
+
+  final fromSnake = _neutralSnakeToCamel[_toSnakeCase(name)];
+  return fromSnake ?? name;
+}


### PR DESCRIPTION
## Summary
- add a normalize helper in aiwa_core so snake_case keypoint names map to the canonical camelCase identifiers
- update video analysis fallbacks and per-joint threshold filtering to reuse the shared keypoint constants
- simplify visualization helpers by normalizing keypoint names before emitting connections or overlay data

## Testing
- not run (flutter tooling unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691058d798608320847b736a8833d0df)